### PR TITLE
feat: 초대 코드 6자리 단축 + 2D 생성 트리거 복구

### DIFF
--- a/Assets/00_Scenes/MVP/MvpNotoSansKR SDF.asset
+++ b/Assets/00_Scenes/MVP/MvpNotoSansKR SDF.asset
@@ -502,6 +502,12 @@ MonoBehaviour:
       m_LigatureGlyphID: 2078
     - m_ComponentGlyphIDs: 1a00000040180000
       m_LigatureGlyphID: 2230
+    - m_ComponentGlyphIDs: 19000000b7130000
+      m_LigatureGlyphID: 2364
+    - m_ComponentGlyphIDs: 1900000057140000
+      m_LigatureGlyphID: 2077
+    - m_ComponentGlyphIDs: 1900000040180000
+      m_LigatureGlyphID: 2229
     m_GlyphPairAdjustmentRecords:
     - m_FirstAdjustmentRecord:
         m_GlyphIndex: 55

--- a/Assets/00_Scenes/MVP/Runtime/Core/MvpClassroomFlow.cs
+++ b/Assets/00_Scenes/MVP/Runtime/Core/MvpClassroomFlow.cs
@@ -1075,7 +1075,7 @@ public class MvpClassroomFlow : MonoBehaviour
         TMP_InputField roomCode = CreateLabeledInput(
             card.transform,
             "방 코드",
-            "선생님이 준 UUID 방 코드를 붙여넣기",
+            "선생님이 알려준 6자리 코드 (예: A1B2C3)",
             new Vector2(0f, 125f),
             new Vector2(720f, 70f),
             "");
@@ -1101,7 +1101,7 @@ public class MvpClassroomFlow : MonoBehaviour
         TMP_Text status = MvpStudentUiFactory.CreateText(
             card.transform,
             "Status",
-            "방 코드는 복사해서 붙여넣으면 편해요.",
+            "6자리 코드를 입력하세요. 대소문자는 상관없어요.",
             new Vector2(0f, -135f),
             new Vector2(720f, 54f),
             20f,
@@ -1212,7 +1212,7 @@ public class MvpClassroomFlow : MonoBehaviour
             MvpStudentUiFactory.CreateText(
                 _contentRoot,
                 "InviteCode",
-                "초대 코드  " + _session.roomId,
+                "초대 코드  " + ShortRoomCode(_session.roomId),
                 new Vector2(-95f, -232f),
                 new Vector2(830f, 42f),
                 19f,
@@ -1232,7 +1232,7 @@ public class MvpClassroomFlow : MonoBehaviour
                 18f);
             copy.onClick.AddListener(() =>
             {
-                GUIUtility.systemCopyBuffer = _session.roomId;
+                GUIUtility.systemCopyBuffer = ShortRoomCode(_session.roomId);
                 TMP_Text label = copy.GetComponentInChildren<TMP_Text>();
                 if (label != null)
                     StartCoroutine(FlashButtonLabel(label, "복사됨!", "코드 복사"));
@@ -2839,6 +2839,91 @@ public class MvpClassroomFlow : MonoBehaviour
         ShowState(MvpFlowState.Briefing);
     }
 
+    // ─────────────────────────────────────────────
+    // 초대 코드 단축 (2026-08-01)
+    // ─────────────────────────────────────────────
+    //
+    // 서버 room_id 는 36자 UUID 라 구두/채팅 공유가 어렵다. 서버 변경 없이 클라에서만
+    // 앞 6자리(하이픈 제외, 대문자)를 초대 코드로 쓰고, 참여 시 GET /api/rooms/list 로
+    // 접두사가 일치하는 방을 찾아 원래 room_id 를 복원한다.
+    //   - 6자리 = 16^6 ≈ 1,670만 조합. 한 교실 규모에서 충돌은 사실상 없다.
+    //   - 접두사가 여러 방과 겹치면 모호하므로 입장을 거부한다(잘못된 방 입장 방지).
+    //   - UUID 를 그대로 붙여넣어도 동작한다(하위호환).
+
+    private const int ShortRoomCodeLength = 6;
+
+    private static string ShortRoomCode(string roomId)
+    {
+        if (string.IsNullOrEmpty(roomId)) return string.Empty;
+
+        string compact = roomId.Replace("-", string.Empty);
+        if (compact.Length < ShortRoomCodeLength) return compact.ToUpperInvariant();
+
+        return compact.Substring(0, ShortRoomCodeLength).ToUpperInvariant();
+    }
+
+    // 6자리 코드 → 전체 room_id. 못 찾거나 모호하면 null 을 넘긴다.
+    private IEnumerator ResolveShortRoomCode(string code, Action<string> onDone)
+    {
+        string normalized = (code ?? string.Empty)
+            .Replace("-", string.Empty)
+            .Trim()
+            .ToUpperInvariant();
+
+        if (string.IsNullOrEmpty(normalized))
+        {
+            onDone?.Invoke(null);
+            yield break;
+        }
+
+        string url = "http://" + _backendHost + "/api/rooms/list";
+        using (UnityWebRequest request = UnityWebRequest.Get(url))
+        {
+            request.timeout = 5;
+            yield return request.SendWebRequest();
+
+            if (request.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogWarning(
+                    "[MVP Flow] 방 목록 조회 실패(초대 코드 해석 불가): " +
+                    request.error);
+                onDone?.Invoke(null);
+                yield break;
+            }
+
+            // 공통 봉투 { isSuccess, code, message, result: { rooms: [ { room_id, ... } ] } }
+            // JsonUtility 는 중첩 제네릭에 약해, room_id 값만 정규식으로 뽑아 접두사 비교한다.
+            string body = request.downloadHandler.text ?? string.Empty;
+            var matches = System.Text.RegularExpressions.Regex.Matches(
+                body,
+                "\"room_id\"\\s*:\\s*\"([0-9a-fA-F-]{36})\"");
+
+            string found = null;
+            int hits = 0;
+            foreach (System.Text.RegularExpressions.Match m in matches)
+            {
+                string candidate = m.Groups[1].Value;
+                if (ShortRoomCode(candidate) != normalized) continue;
+
+                hits++;
+                found = candidate;
+            }
+
+            if (hits > 1)
+            {
+                Debug.LogWarning(
+                    "[MVP Flow] 초대 코드가 여러 방과 일치합니다(모호): " + normalized);
+                onDone?.Invoke(null);
+                yield break;
+            }
+
+            Debug.Log(hits == 1
+                ? "[MVP Flow] 초대 코드 해석: " + normalized + " → " + found
+                : "[MVP Flow] 초대 코드에 해당하는 방 없음: " + normalized);
+            onDone?.Invoke(found);
+        }
+    }
+
     private IEnumerator JoinRoomRoutine(
         string roomId,
         string nickname,
@@ -2847,7 +2932,9 @@ public class MvpClassroomFlow : MonoBehaviour
         Button submit)
     {
         if (_requestBusy) yield break;
-        if (!Guid.TryParse(roomId?.Trim(), out Guid parsedRoomId) ||
+
+        string typed = roomId?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(typed) ||
             string.IsNullOrWhiteSpace(nickname) ||
             string.IsNullOrWhiteSpace(password))
         {
@@ -2862,10 +2949,33 @@ public class MvpClassroomFlow : MonoBehaviour
         status.text = "방에 입장하고 있어요...";
         status.color = MvpStudentUiFactory.Primary;
 
+        // [2026-08-01] 초대 코드를 6자리로 단축(ShortRoomCode). UUID 전체를 붙여넣던 방식은
+        //   공유가 불편해 앞 6자리만 쓰고, 여기서 GET /api/rooms/list 로 원래 room_id 를 되찾는다.
+        //   UUID 를 그대로 붙여넣어도 동작하도록 둘 다 받는다(하위호환).
+        string resolvedRoomId = null;
+        if (Guid.TryParse(typed, out Guid parsedFull))
+        {
+            resolvedRoomId = parsedFull.ToString();
+        }
+        else
+        {
+            yield return ResolveShortRoomCode(typed, id => resolvedRoomId = id);
+        }
+
+        if (string.IsNullOrEmpty(resolvedRoomId))
+        {
+            status.text =
+                "그 코드의 방을 찾지 못했어요. 코드를 다시 확인해 주세요.";
+            status.color = MvpStudentUiFactory.DangerInk;
+            _requestBusy = false;
+            submit.interactable = true;
+            yield break;
+        }
+
         bool entered = false;
         string userId = "";
         yield return TryEnterRoom(
-            parsedRoomId.ToString(),
+            resolvedRoomId,
             nickname.Trim(),
             password.Trim(),
             (ok, id) =>
@@ -2884,7 +2994,7 @@ public class MvpClassroomFlow : MonoBehaviour
             yield break;
         }
 
-        _session.roomId = parsedRoomId.ToString();
+        _session.roomId = resolvedRoomId;
         _session.roomName = "함께하는 물로켓 수업";
         _session.topic = "새로운 설계 아이디어";
         _session.goal = "우리 팀만의 해결책 만들기";

--- a/Assets/00_Scenes/MVP/Runtime/Graph/MvpWaterRocketGraphController.cs
+++ b/Assets/00_Scenes/MVP/Runtime/Graph/MvpWaterRocketGraphController.cs
@@ -26,14 +26,24 @@ public class MvpWaterRocketGraphController : MonoBehaviour
         }
     }
 
+    // [2026-08-01] _partIds(내부 맵) 대신 GraphManager 를 단일 출처로 삼는다.
+    //   AddPartPort → PartNodeApiClient → GraphManager.RequestCreatePartNode 로 만든 파트는
+    //   _partIds 에 등록되지 않아 PartCount 가 0 으로 남았고, 그 탓에 '그림 생성하기' 버튼의
+    //   활성 조건(MvpClassroomFlow:3138-3142)이 영원히 거짓이 되어 onClick 이 발생하지 않았다
+    //   (퀘스트 실기 확인 — 서버에 파트·속성·엣지가 모두 있는데도 버튼이 잠김).
+    //   RequirementCount / AppliedConnectionCount 는 이미 GraphManager 를 보고 있어 이제 셋이 일관된다.
+    //   is_global(=ALL) 제외는 기존의 "전체" 키 제외와 같은 의미다. _partIds 는 라벨 매핑용으로 유지.
     public int PartCount
     {
         get
         {
             int count = 0;
-            foreach (KeyValuePair<string, string> pair in _partIds)
-                if (pair.Key != "전체" &&
-                    !string.IsNullOrEmpty(pair.Value))
+            if (_graphManager == null) return count;
+
+            foreach (NodeData node in _graphManager.GetAllNodes())
+                if (node != null &&
+                    node.NodeType == NodeType.PART &&
+                    !node.is_global)
                     count++;
             return count;
         }

--- a/Assets/01_Prefabs/Graph/Designer/NewNodebox.prefab
+++ b/Assets/01_Prefabs/Graph/Designer/NewNodebox.prefab
@@ -275,6 +275,7 @@ RectTransform:
   - {fileID: 8418678945948843022}
   - {fileID: 5128331510812941544}
   - {fileID: 600182784828761053}
+  - {fileID: 8725317176168670241}
   m_Father: {fileID: 8865337395798813981}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -492,6 +493,142 @@ MonoBehaviour:
   m_enableKerning: 0
   m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 1
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7552335367546381678
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2461119164631379249}
+  - component: {fileID: 2870945535109789569}
+  - component: {fileID: 5348133402387490157}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2461119164631379249
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7552335367546381678}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8725317176168670241}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2870945535109789569
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7552335367546381678}
+  m_CullTransparentMesh: 1
+--- !u!114 &5348133402387490157
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7552335367546381678}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\uC5F0\uACB0"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: a474e78634c714c179e5c7c74fb95c6d, type: 2}
+  m_sharedMaterial: {fileID: -5124638249707594488, guid: a474e78634c714c179e5c7c74fb95c6d, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
   m_EmojiFallbackSupport: 1
@@ -1052,6 +1189,127 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &8994601318599840716
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8725317176168670241}
+  - component: {fileID: 6044409135427673750}
+  - component: {fileID: 5763701647169628462}
+  - component: {fileID: 1562774639742735631}
+  m_Layer: 5
+  m_Name: LinkButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8725317176168670241
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8994601318599840716}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.02, y: 0.02, z: 0.02}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2461119164631379249}
+  m_Father: {fileID: 7788993220151074083}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -1.76}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6044409135427673750
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8994601318599840716}
+  m_CullTransparentMesh: 1
+--- !u!114 &5763701647169628462
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8994601318599840716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1562774639742735631
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8994601318599840716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5763701647169628462}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &4342213659168250063
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1198,6 +1456,8 @@ MonoBehaviour:
   _deleteButton: {fileID: 422650956623136945}
   _addButton: {fileID: 6025988780693341223}
   _referenceButton: {fileID: 4617160746754829857}
+  _linkButton: {fileID: 1562774639742735631}
+  _linkLabel: {fileID: 5348133402387490157}
 --- !u!23 &8196454958159288565 stripped
 MeshRenderer:
   m_CorrespondingSourceObject: {fileID: 5619661150120591418, guid: 53c404f8bde7544dcb41c9f174ff4bec, type: 3}

--- a/Assets/02_Scripts/Graph/Server/Generate2DController.cs
+++ b/Assets/02_Scripts/Graph/Server/Generate2DController.cs
@@ -40,6 +40,17 @@ public class Generate2DController : MonoBehaviour
         ResolveReferences();
         if (_syncClient != null)
             _syncClient.OnImage2DGenerated += HandleImageGenerated;
+
+        // [2026-08-01] _generateButton 은 지금까지 interactable 제어에만 쓰였고 클릭 리스너가 없었다.
+        //   그 결과 2D 생성 진입점이 MvpClassroomFlow 의 버튼 하나뿐이었다.
+        //   (중복 호출은 _isGenerating 가드가 막는다. 비어 있으면 아무 일도 없다.)
+        if (_generateButton != null)
+        {
+            _generateButton.onClick.RemoveListener(RequestGenerateGraphAll);
+            _generateButton.onClick.AddListener(RequestGenerateGraphAll);
+        }
+
+
         SetStatus("부품과 속성을 연결한 뒤 생성하세요.");
         SetButtonInteractable(true);
     }
@@ -48,9 +59,12 @@ public class Generate2DController : MonoBehaviour
     {
         if (_syncClient != null)
             _syncClient.OnImage2DGenerated -= HandleImageGenerated;
+        if (_generateButton != null)
+            _generateButton.onClick.RemoveListener(RequestGenerateGraphAll);
         StopGenerationTimeout();
         _isGenerating = false;
     }
+
 
     // ─────────────────────────────────────────────
     // 생성/변경 요청 (결과는 WS 2D_GENERATED 로 별도 통보)


### PR DESCRIPTION
[초대 코드 6자리]
36자 UUID 를 그대로 노출해 구두/채팅 공유가 어려웠다. 서버 변경 없이 클라에서만
앞 6자(하이픈 제외·대문자)를 코드로 쓰고, 참여 시 GET /api/rooms/list 로 접두사가 일치하는 방을 찾아 원래 room_id 를 복원한다.
- ShortRoomCode() / ResolveShortRoomCode() 추가
- 표시·복사 버튼·입력 안내 문구를 6자리 기준으로 변경
- UUID 전체 입력도 계속 허용(하위호환), 대소문자 무관
- 접두사가 여러 방과 겹치면 입장을 거부(엉뚱한 방 입장 방지). 6자 = 약 1670만 조합

[2D 생성이 아예 트리거되지 않던 문제]
퀘스트 실기에서 '그림 생성하기' 를 눌러도 Generate2DController 로그가 0건이었다. 원인은 버튼의 interactable 이 항상 false 였던 것 — MvpClassroomFlow:3138 의 활성 조건이 MvpWaterRocketGraphController 의 카운트를 보는데, 그중 PartCount 만 GraphManager 가 아닌 내부 맵 _partIds 를 세고 있었다. AddPartPort → PartNodeApiClient → RequestCreatePartNode 로 만든 파트는 _partIds 에 없어 PartCount 가 0 으로 고정됐고, Button 은 interactable=false 면 onClick 을 발생시키지 않으므로 어떤 핸들러도 호출되지 않았다.
- PartCount 를 GraphManager 의 PART 노드 기준으로 변경(is_global=ALL 제외). RequirementCount / AppliedConnectionCount 는 이미 GraphManager 기반이라 이제 셋이 일관.
- Generate2DController: _generateButton 에 onClick 리스너 연결(그동안 interactable 제어에만 사용).

[속성↔파트 연결 버튼]
NewNodebox 프리팹에 LinkButton 추가 및 NodeActionPanel._linkButton/_linkLabel 배선. 탭하면 무장(라벨 '취소'), 이어서 PART/ALL 포트를 탭하면 연결된다.

검증: 서버 2D 생성 경로는 REST 직접 호출로 확인 완료(요청 200 → 이미지 생성 → MinIO 다운로드 200, 544KB JPEG). 실기에서도 사용자가 만든 노드로 생성 요청이 나가고 2D_GENERATED 수신까지 확인됐다(이미지 다운로드는 별건으로 조사 중).