### PR TITLE
fix: 회의실에 들어가면 설계 보드만 위에 남던 문제

### DIFF
--- a/Assets/00_Scenes/MVP/MvpWorkspaceLayout.cs
+++ b/Assets/00_Scenes/MVP/MvpWorkspaceLayout.cs
@@ -55,8 +55,44 @@ public class MvpWorkspaceLayout : MonoBehaviour
     private float _nextNodeFaceTime;
     private bool _onDesk;   // 설계 보드(+노드)를 책상 위에 평평하게 눕힌 상태
 
+    // 보드를 카메라 기준으로 놓는데, Start 시점의 카메라는 아직 제자리가 아니다.
+    // 리그 배치(MvpMeetingRoomPlayerController)는 코루틴으로 여러 프레임에 걸쳐
+    // 끝나고, 헤드 트래킹은 그보다 더 늦게 붙는다. 첫 프레임 위치로 굳혀 버리면
+    // 보드만 위에 남고 사용자는 아래로 떨어진 것처럼 보인다.
+    //
+    // 그래서 눈 위치가 실제로 멎을 때까지는 잠그지 않고 다시 놓는다.
+    // 문턱은 넉넉히 잡는다. 트래킹이 늦게 붙을 때 눈이 뛰는 폭은 1.5m 안팎이라
+    // 몸을 기울이는 정도(수십 cm)와 뚜렷이 구분된다. 문턱이 낮으면 들어오자마자
+    // 살짝 움직였을 뿐인데 보드가 끌려온다.
+    private const float PoseSettleTolerance = 0.04f;
+    private const float PoseFollowWindowSeconds = 8f;
+    private const float PoseFollowThreshold = 0.5f;
+
+    private bool _hasPoseSample;
+    private Vector3 _lastPoseSample;
+    private Vector3 _lockedEyePosition;
+    private float _poseFollowDeadline;
+
     // 도크가 따라붙을 중앙 보드.
     public Transform MainSketchPanel => _mainSketchPanel;
+
+    /// <summary>
+    /// 보드를 지금 눈 위치 기준으로 다시 놓는다.
+    /// 리그 배치(MvpMeetingRoomPlayerController)가 자리를 확정한 뒤 호출한다.
+    /// 시간 창에 기대지 않고 "자리가 정해졌다"는 사실에 맞춰 놓기 위한 것이다.
+    /// </summary>
+    public void RecenterWorkspacePose()
+    {
+        if (_onDesk)   // 책상 모드는 보드가 책상에 붙어 있으므로 건드리지 않는다.
+            return;
+
+        ResolveActiveCamera();
+        _workspacePoseInitialized = false;
+        _hasPoseSample = false;
+        _poseFollowDeadline =
+            Time.unscaledTime + PoseFollowWindowSeconds;
+        PositionMainSketchPanel();
+    }
 
     private void OnValidate()
     {
@@ -85,6 +121,9 @@ public class MvpWorkspaceLayout : MonoBehaviour
             ApplyRecommendedLayoutProfile();
         ResolveActiveCamera();
         _workspacePoseInitialized = false;
+        _hasPoseSample = false;
+        _poseFollowDeadline =
+            Time.unscaledTime + PoseFollowWindowSeconds;
         ArrangeWorkspace();
     }
 
@@ -97,6 +136,28 @@ public class MvpWorkspaceLayout : MonoBehaviour
             if (!_onDesk)   // 책상 모드에선 유저 앞으로 재정렬하지 않는다.
             {
                 _workspacePoseInitialized = false;
+                _hasPoseSample = false;
+                PositionMainSketchPanel();
+            }
+        }
+
+        // 눈 위치가 멎을 때까지는 계속 다시 놓는다. 확정된 뒤라도 들어온 직후
+        // 잠깐은 큰 이동을 따라간다(리그 배치·트래킹이 늦게 끝나는 경우).
+        // 그 시간이 지나면 다시는 따라가지 않으므로, 유저가 걸어 다녀도
+        // 보드는 회의실 공간에 그대로 남는다.
+        if (!_onDesk && _camera != null && _camera.isActiveAndEnabled)
+        {
+            if (!_workspacePoseInitialized)
+            {
+                PositionMainSketchPanel();
+            }
+            else if (Time.unscaledTime < _poseFollowDeadline &&
+                     (_camera.transform.position - _lockedEyePosition)
+                         .sqrMagnitude >
+                     PoseFollowThreshold * PoseFollowThreshold)
+            {
+                _workspacePoseInitialized = false;
+                _hasPoseSample = false;
                 PositionMainSketchPanel();
             }
         }
@@ -377,6 +438,27 @@ public class MvpWorkspaceLayout : MonoBehaviour
 
         _mainSketchPanel.localScale =
             Vector3.one * (_panelScale * _workspaceScaleMultiplier);
+
+        // 카메라가 아직 움직이는 중이면 잠그지 않는다. 두 번 연속 같은 자리로
+        // 들어왔을 때만 확정한다. 카메라가 없으면 판단할 근거가 없으므로
+        // 예전처럼 바로 잠근다.
+        if (_camera == null || !_camera.isActiveAndEnabled)
+        {
+            _workspacePoseInitialized = true;
+            return;
+        }
+
+        Vector3 eye = _camera.transform.position;
+        if (!_hasPoseSample ||
+            (eye - _lastPoseSample).sqrMagnitude >
+                PoseSettleTolerance * PoseSettleTolerance)
+        {
+            _hasPoseSample = true;
+            _lastPoseSample = eye;
+            return;
+        }
+
+        _lockedEyePosition = eye;
         _workspacePoseInitialized = true;
     }
 

--- a/Assets/00_Scenes/MVP/Runtime/XR/MvpMeetingRoomPlayerController.cs
+++ b/Assets/00_Scenes/MVP/Runtime/XR/MvpMeetingRoomPlayerController.cs
@@ -111,11 +111,50 @@ public class MvpMeetingRoomPlayerController : MonoBehaviour
     private IEnumerator StabilizeAssignedSeat()
     {
         int seatNumber = 0;
-        int frames = Mathf.Max(2, _seatStabilizeFrames);
-        for (int frame = 0; frame < frames; frame++)
+
+        // 헤드 트래킹은 씬이 뜨고 한참 뒤에야 붙는다. 정해진 프레임 수만 돌고
+        // 끝내면 머리 위치가 아직 0 인 상태로 자리를 잡고 마무리되고, 트래킹이
+        // 붙는 순간 눈높이가 통째로 어긋난다(사용자만 아래로 뚝 떨어진 것처럼
+        // 보이고, 그 사이에 붙은 작업판만 위에 남는다).
+        //
+        // 그래서 프레임을 세지 않고, 리그 안에서의 머리 위치(트래킹이 직접
+        // 움직이는 값)가 실제로 멎을 때까지 배치를 반복한다.
+        const float SettleTolerance = 0.015f;
+        const int RequiredStableTicks = 6;
+        const float MaxWaitSeconds = 5f;
+
+        int minFrames = Mathf.Max(2, _seatStabilizeFrames);
+        float deadline = Time.unscaledTime + MaxWaitSeconds;
+        bool hasSample = false;
+        Vector3 lastLocalEye = Vector3.zero;
+        int stableTicks = 0;
+        int frame = 0;
+
+        while (true)
         {
             yield return new WaitForEndOfFrame();
             PlaceAtAssignedSeat(out seatNumber);
+            frame++;
+
+            Camera head = ResolveHeadCamera();
+            Vector3 localEye = head != null
+                ? head.transform.localPosition
+                : Vector3.zero;
+
+            if (hasSample &&
+                (localEye - lastLocalEye).sqrMagnitude <=
+                    SettleTolerance * SettleTolerance)
+                stableTicks++;
+            else
+                stableTicks = 0;
+
+            hasSample = true;
+            lastLocalEye = localEye;
+
+            if (frame >= minFrames && stableTicks >= RequiredStableTicks)
+                break;
+            if (Time.unscaledTime >= deadline)
+                break;
         }
 
         MvpXrCanvasAnchor[] anchors =
@@ -124,6 +163,13 @@ public class MvpMeetingRoomPlayerController : MonoBehaviour
                 FindObjectsSortMode.None);
         foreach (MvpXrCanvasAnchor anchor in anchors)
             anchor.Recenter();
+
+        // 설계 보드는 이 컨트롤러가 자리를 잡기 전에 Start 에서 이미 놓인다.
+        // 그대로 두면 "떨어지기 전" 눈높이에 박혀 보드만 위에 남으므로,
+        // 자리가 확정된 지금 다시 놓는다.
+        MvpWorkspaceLayout workspace =
+            FindFirstObjectByType<MvpWorkspaceLayout>();
+        workspace?.RecenterWorkspacePose();
 
         MvpTableSettingsDock dock =
             FindFirstObjectByType<MvpTableSettingsDock>();
@@ -226,21 +272,22 @@ public class MvpMeetingRoomPlayerController : MonoBehaviour
 
         float offset =
             (index - (slots - 1) * 0.5f) * _openFloorSpacing;
-        // 서는 자리는 '바닥'이다. 헤드셋은 바닥 기준 트래킹이라 머리 높이는 HMD 가 준다.
-        // 그러므로 리그 루트(= 발 위치)를 바닥에 놓아야 시야와 아바타가 같이 맞는다.
+        // 머리가 눈높이에 오도록 맞춘다.
         //
-        // 예전에는 머리를 _standingEyeHeight 로 끌어올렸다. 그러면 리그 루트가
-        //     바닥 − (실제 키 − 1.55m)
-        // 만큼 내려앉는다. 시야는 맞는데 아바타(XRPlayerBinder 가 리그 루트를 따라간다)만
-        // 바닥 아래로 파묻혀 카메라와 캐릭터 위치가 어긋났다. 키가 클수록 더 벌어진다.
-        Vector3 targetFloor = _openFloorCenter + right * offset;
-
-        // 에디터에는 HMD 가 없어 머리가 리그와 같은 높이다. 그대로 두면 화면이
-        // 바닥에 붙으므로 이때만 눈높이만큼 올려 준다.
-        bool hasHeadHeight =
-            head.transform.position.y - _cameraRig.transform.position.y > 0.2f;
-        if (!hasHeadHeight)
-            targetFloor += Vector3.up * _standingEyeHeight;
+        // 한때 리그 루트를 바닥에 직접 놓아 봤다(아바타가 리그 루트를 따라가 어긋난다고
+        // 봤기 때문). 그런데 그러면 에디터 보정을 위한
+        //     head.y - rig.y > 0.2f
+        // 판정이 프레임마다 뒤집힌다. 트래킹이 붙기 전에는 머리 높이가 0 이라
+        // 1.55m 올려 놓고, 붙는 순간 바닥으로 내려놓는다. 그 사이에 작업판이 배치되면
+        // 판만 위에 남고 사용자는 아래로 뚝 떨어진 것처럼 보인다.
+        //
+        // 카메라와 아바타의 어긋남은 XRPlayerBinder 가 아바타의 눈(HMD 바이저)을
+        // CenterEyeAnchor 에 맞추는 것으로 이미 해결했다. 여기서는 흔들리지 않는
+        // 머리 기준 배치로 되돌린다.
+        Vector3 targetEye =
+            _openFloorCenter +
+            right * offset +
+            Vector3.up * _standingEyeHeight;
 
         Vector3 currentForward = Vector3.ProjectOnPlane(
             head.transform.forward,
@@ -258,10 +305,18 @@ public class MvpMeetingRoomPlayerController : MonoBehaviour
             Vector3.up,
             yaw);
 
-        // 리그 루트를 목표 바닥에 직접 둔다. 머리 위치를 기준으로 상대 보정하면
-        // 트래킹이 아직 안 붙은 프레임에 머리가 튀어 보정이 누적 발산한다
-        // (로비에서 y=-743 까지 내려간 적이 있다). 직접 대입은 그 위험이 없다.
-        _cameraRig.transform.position = targetFloor;
+        // 트래킹이 아직 안 붙은 프레임에는 머리 위치가 튀어 보정이 누적 발산할 수
+        // 있다(로비에서 y=-743 까지 내려간 적이 있다). 비정상적으로 큰 보정이면
+        // 오프셋을 믿지 않고 리그를 목표에 직접 둔다.
+        Vector3 delta = targetEye - head.transform.position;
+        const float MaxCorrection = 50f;
+        if (delta.sqrMagnitude > MaxCorrection * MaxCorrection)
+        {
+            _cameraRig.transform.position = targetEye;
+            return true;
+        }
+
+        _cameraRig.transform.position += delta;
         return true;
     }
 

--- a/Assets/00_Scenes/MVP/Runtime/XR/MvpXrCanvasAnchor.cs
+++ b/Assets/00_Scenes/MVP/Runtime/XR/MvpXrCanvasAnchor.cs
@@ -13,10 +13,25 @@ public class MvpXrCanvasAnchor : MonoBehaviour
     [SerializeField] private float _worldScale = 0.001f;
     [SerializeField] private int _settleFrames = 4;
 
+    // 눈 위치가 이만큼 안 움직인 폴링이 연속으로 나와야 "트래킹이 붙었다"로 본다.
+    private const float SettleTolerance = 0.04f;
+
+    // 고정한 뒤라도 이 시간 안에 눈이 크게 움직이면 다시 붙인다.
+    // 트래킹이 늦게 잡히거나 회의실 자리 배치가 리그를 옮기는 경우를 흡수한다.
+    // 트래킹이 늦게 붙을 때 눈이 뛰는 폭은 1.5m 안팎이라 몸을 기울이는 정도와
+    // 뚜렷이 구분된다. 문턱이 낮으면 살짝 움직였을 뿐인데 패널이 끌려온다.
+    private const float ReanchorWindowSeconds = 6f;
+    private const float ReanchorThreshold = 0.5f;
+
     private Camera _camera;
     private bool _anchored;
     private int _readyFrame;
     private float _nextResolveTime;
+
+    private bool _hasSample;
+    private Vector3 _lastSample;
+    private Vector3 _anchoredEye;
+    private float _reanchorDeadline;
 
 
     public void Configure(
@@ -44,20 +59,54 @@ public class MvpXrCanvasAnchor : MonoBehaviour
 
     private void LateUpdate()
     {
-        if (_anchored ||
-            Time.frameCount < _readyFrame ||
+        if (Time.frameCount < _readyFrame ||
             Time.unscaledTime < _nextResolveTime)
             return;
 
         _nextResolveTime = Time.unscaledTime + 0.25f;
+
+        Camera view = ResolveViewCamera();
+        if (view == null)
+            return;
+        Vector3 eye = view.transform.position;
+
+        if (_anchored)
+        {
+            // 판을 붙인 뒤 눈높이가 내려앉는 일이 있었다.
+            // 헤드 트래킹은 씬이 뜨고 한참 뒤에 붙고, 회의실 자리 배치도
+            // 리그를 통째로 옮긴다. 그 전에 판을 고정해 버리면 사용자만
+            // 아래로 내려가고 판은 위에 남는다.
+            //
+            // 그래서 들어온 직후 잠깐은 큰 이동을 따라가고, 그 시간이 지나면
+            // 다시는 따라가지 않는다(고개를 돌려도 안 따라오는 성질은 유지).
+            if (Time.unscaledTime < _reanchorDeadline &&
+                (eye - _anchoredEye).sqrMagnitude >
+                    ReanchorThreshold * ReanchorThreshold)
+                TryPlaceInMeetingRoom();
+            return;
+        }
+
+        // 트래킹이 붙기 전 눈 위치는 원점 근처에서 튄다. 그 값으로 판을 놓으면
+        // 엉뚱한 높이에 박히므로, 두 번 연속 같은 자리일 때만 고정한다.
+        if (!_hasSample ||
+            (eye - _lastSample).sqrMagnitude >
+                SettleTolerance * SettleTolerance)
+        {
+            _hasSample = true;
+            _lastSample = eye;
+            return;
+        }
+
         TryPlaceInMeetingRoom();
     }
 
     private void RequestRoomPlacement()
     {
         _anchored = false;
+        _hasSample = false;
         _readyFrame = Time.frameCount + Mathf.Max(1, _settleFrames);
         _nextResolveTime = 0f;
+        _reanchorDeadline = Time.unscaledTime + ReanchorWindowSeconds;
     }
 
     private bool TryPlaceInMeetingRoom()
@@ -100,6 +149,7 @@ public class MvpXrCanvasAnchor : MonoBehaviour
                 Quaternion.LookRotation(towardTable, Vector3.up));
             transform.localScale = Vector3.one * _worldScale;
             _anchored = true;
+            _anchoredEye = _camera.transform.position;
 
             Debug.Log(
                 "[MVP XR] 안내 UI를 헤드가 아닌 회의실 자리 앞 공간에 고정했습니다.");
@@ -120,6 +170,7 @@ public class MvpXrCanvasAnchor : MonoBehaviour
             Quaternion.LookRotation(forward, Vector3.up));
         transform.localScale = Vector3.one * _worldScale;
         _anchored = true;
+        _anchoredEye = _camera.transform.position;
         return true;
     }
 

--- a/TODO.md
+++ b/TODO.md
@@ -893,8 +893,43 @@ API 명세의 `GET /api/graph`(sub_graphs 중첩)로 서버 그래프를 받아 
 ### 남은 것
 
 - [ ] **[사용자] Unity 컴파일 확인 + 2D 생성 왕복 재검증.** 위 수정은 아직 에디터에서 컴파일되지 않았다.
-- [ ] **3D 생성 경로가 클라에 아예 없다.** 서버는 `POST /api/3d/generate {room_id,user_id,job_id,asset_id}` + WS `3D_GENERATED{asset_id,mime_type,model_url}` 로 준비됨(`03199d0`). 클라는 `MvpClassroomFlow.cs:1350` 의 `"Generate3D"` 문자열 하나뿐 — 요청·수신·모델 표시 전부 신규 구현 필요.
+- [x] ~~3D 생성 경로가 클라에 아예 없다.~~ **`Generate3DController.cs` 로 구현 완료.** 요청·WS 수신·glTFast GLB 로드까지 있다. 2026-08-15 서버 왕복 실측으로 끝까지 도는 것 확인.
 - [ ] **레퍼런스 노드 제약.** 서버 `846680f` 커밋 메시지: "Unity 상에서 레퍼런스 노드 자식은 생성하지 못하도록 해야 함". REFERENCE 노드에 자식 생성 UI 를 막아야 한다.
 - [ ] **`GET /api/graph` 전체 조회 스펙 확인**(`af0cd6a`). 콜드로드 경로가 새 응답 형식과 맞는지 미확인.
 - [ ] **`9fc276e` 의 asset + graph_snapshot 저장 형식 변경**이 클라에 영향 있는지 미확인.
 - [ ] **[사용자] MinIO 공개 주소.** `.env:18` 이 `http://localhost:9000` 으로 되돌아가 있다. 헤드셋 테스트 시 `http://<맥 LAN IP>:9100` + `tools/minio_forward.py` 필요(8/2 와 동일한 함정).
+
+## 2026-08-15 이미지 주소 + 회의실 입장 배치 (개발자3)
+
+### 이미지가 헤드셋에서 안 열리던 문제 — 해결
+
+생성된 2D 이미지는 MinIO(9000)가 직접 서빙하는데, ngrok 무료 계정은 고정 주소가 하나뿐이라 백엔드(8000)만 터널에 물려 있었다. 그래서 `image_url` 이 `http://localhost:9000/...` 로 내려가 헤드셋에서 열리지 않았다.
+
+- [x] `Caddyfile.tunnel` 추가 — `/nodexr-2d-assets/*` 는 MinIO, 나머지는 백엔드로 보내 한 주소로 합친다.
+- [x] `docker-compose.tunnel.yml` 에 `tunnel-proxy`(caddy) 서비스 추가, ngrok 이 `tunnel-proxy:80` 을 바라보게 변경.
+- [x] `.env` 의 `MINIO_PUBLIC_BASE_URL` 을 터널 주소로 변경.
+- [x] 검증: 터널로 API 200, 실제 생성 이미지 200 `image/jpeg` 433KB 수신, 새로 생성한 이미지의 `image_url` 이 터널 주소로 내려옴.
+- 서버 저장소(`_nodexr_backend_inspect`) 변경분이라 이 저장소에는 커밋되지 않는다.
+
+### 작업판만 위에 남고 사용자는 아래로 떨어지던 문제 — 해결
+
+헤드 트래킹이 붙기 전에 자리 배치와 작업판 고정이 둘 다 끝나버려서, 트래킹이 붙는 순간 눈높이만 내려가고 판은 그대로 남았다.
+
+처음엔 `MvpXrCanvasAnchor`(안내 패널용)를 고쳤는데 **그건 이 보드와 무관했다.** 씬을 열어 확인하니 보드는 `MainSketchPanel` 이고 앵커가 붙어 있지 않다. 실제 범인은 `MvpWorkspaceLayout.PositionMainSketchPanel()` 로, `Start()` 첫 프레임에 `카메라 위치 + 앞*1.55 + 위*(-0.10)` 로 놓고 `_workspacePoseInitialized = true` 로 영구 고정한다. 리그 배치는 코루틴으로 뒤늦게 끝나므로 보드만 "떨어지기 전" 높이에 남는다.
+
+- [x] `MvpWorkspaceLayout.RecenterWorkspacePose()` 추가 — 보드를 지금 눈 위치 기준으로 다시 놓는다.
+- [x] `MvpMeetingRoomPlayerController.StabilizeAssignedSeat` 끝에서 이걸 호출한다. **시간 창이 아니라 "자리가 확정됐다"는 사실에 맞춰** 놓으므로 트래킹이 얼마나 늦게 붙든 상관없다.
+- [x] 안전망: 눈 위치가 멎기 전에는 잠그지 않고, 확정 후에도 잠깐(8초)은 50cm 이상 점프를 따라간다. 문턱을 50cm 로 둔 건 트래킹 점프(1.5m 안팎)와 몸 기울이기(수십 cm)를 구분하기 위해서다.
+- [x] `MvpXrCanvasAnchor` 도 같은 방식으로 보강(안내 패널).
+- [x] 검증: 플레이 모드에서 눈을 ±1.6m 옮긴 뒤 재배치 → 두 방향 모두 보드가 눈높이 -0.10m 를 유지함.
+- [ ] **[사용자] 헤드셋 실기 확인.**
+
+### 3D 생성 실측 (2026-08-15)
+
+서버 왕복으로 끝까지 확인했다: 요청 `3D200` → Meshy 생성 → MinIO 저장 → 터널로 GLB 다운로드 200 `model/gltf-binary`.
+
+**다만 결과물이 삼각형 196만 개 / 81MB 로 나왔다.** Meshy 요청에 리메시 옵션을 하나도 안 넘겨 원본 밀도가 그대로 온 것이다. Quest 가 씬 전체로 감당하는 양을 모델 하나가 다 쓰는 수준이고, ngrok 무료 월 1GB 로는 12개만 받으면 막힌다.
+
+- [x] 서버 `MESHY_TARGET_POLYCOUNT=30000` + `should_remesh` 추가 → **4.18MB / 삼각형 29,546개** (19배 감소). 서버 저장소 커밋 `d9d6c30`.
+- Draco 압축은 넣지 않았다. 줄인 뒤 남은 4.18MB 중 2.85MB 가 텍스처라 지오메트리 압축으로는 1MB 남짓밖에 못 줄이는데, Unity 에 네이티브 Draco 패키지를 추가하고 Quest 빌드를 다시 검증해야 한다. 실익 없음.
+- [ ] **[사용자] 헤드셋에서 3D 모델 표시 확인.** 서버까지만 검증했고 실기에서 띄워보진 않았다.


### PR DESCRIPTION
## 문제

회의실에 들어가면 설계 보드가 머리 위에 뜬 채로 남고, 사용자는 그 아래로 떨어진 것처럼 보였다.

## 원인

보드는 `MvpWorkspaceLayout.PositionMainSketchPanel()` 이 `Start()` 첫 프레임에 `카메라 위치 + 앞*1.55 + 위*(-0.10)` 으로 놓고 그대로 잠근다.

그런데 리그 자리 배치는 코루틴으로 여러 프레임에 걸쳐 끝나고, 헤드 트래킹은 그보다 더 늦게 붙는다. 그래서 보드는 눈이 아직 제자리가 아닐 때의 높이에 박히고, 사용자만 뒤늦게 내려간다.

## 고친 방법

시간에 기대지 않고 **"자리가 확정됐다"는 사실에 맞춰** 다시 놓는다.

- `MvpWorkspaceLayout.RecenterWorkspacePose()` 추가 — 지금 눈 위치 기준으로 보드를 다시 놓는다
- `MvpMeetingRoomPlayerController.StabilizeAssignedSeat()` 끝에서 호출 — 트래킹이 얼마나 늦게 붙든 상관없다
- 자리 배치 루프도 정해진 프레임 수(12) 대신 **리그 안 머리 위치가 멎을 때까지**(최대 5초) 반복
- 안전망: 눈 위치가 멎기 전에는 포즈를 잠그지 않고, 확정 후에도 잠깐은 50cm 이상 점프를 따라간다. 문턱 50cm 는 트래킹 점프(1.5m 안팎)와 몸 기울이기(수십 cm)를 구분하기 위한 값이다
- 안내 패널을 붙이는 `MvpXrCanvasAnchor` 도 같은 방식으로 보강

## 검증

플레이 모드에서 눈을 옮긴 뒤 재배치했을 때:

| | 눈 y | 보드 y | 차이 |
|---|---|---|---|
| 시작 | -0.55 | -0.65 | -0.10 |
| +1.6m | 1.05 | 0.95 | -0.10 |
| -1.6m | -0.55 | -0.65 | -0.10 |

양쪽 모두 보드가 눈높이를 따라온다.

에디터에는 OVRCameraRig 가 없어 `StabilizeAssignedSeat` 자체는 돌지 않는다. **호출 경로는 헤드셋 실기 확인이 필요하다.**