### PR TITLE
feat: 회의실에서 리포트·3D 모델·음성이 공유되지 않던 문제

### DIFF
--- a/Assets/00_Scenes/MVP/MVP_SH.unity
+++ b/Assets/00_Scenes/MVP/MVP_SH.unity
@@ -3246,6 +3246,57 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 700271894}
   m_CullTransparentMesh: 1
+--- !u!1 &729180022
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 729180024}
+  - component: {fileID: 729180023}
+  m_Layer: 0
+  m_Name: MvpGenerated3DModelSyncRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &729180023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 729180022}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a93f95e599674f744919710cf166a5fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphNetwork: {fileID: 0}
+  generate3DController: {fileID: 0}
+  graphSyncClient: {fileID: 0}
+  classroomFlow: {fileID: 0}
+  statusText: {fileID: 0}
+  autoFindReferences: 1
+  broadcastDirectServerResults: 1
+--- !u!4 &729180024
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 729180022}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &744572941
 GameObject:
   m_ObjectHideFlags: 0
@@ -10188,6 +10239,9 @@ GameObject:
   - component: {fileID: 1137757601}
   - component: {fileID: 1137757600}
   - component: {fileID: 1137757599}
+  - component: {fileID: 1137757604}
+  - component: {fileID: 1137757603}
+  - component: {fileID: 1137757602}
   m_Layer: 0
   m_Name: MvpNetwork
   m_TagString: Untagged
@@ -10242,6 +10296,102 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1137757602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137757598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 33a38d73a8571ce438052dd31e09df5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DisconnectAfterKeepAlive: 0
+  KeepAliveInBackground: 60000
+  ApplyDontDestroyOnLoad: 1
+  runInBackground: 1
+  statsResetInterval: 1000
+  speakerPrefab: {fileID: 0}
+  primaryRecorder: {fileID: 1137757604}
+  usePrimaryRecorder: 1
+  cppCompatibilityMode: 0
+  Settings:
+    AppIdRealtime: 
+    AppIdFusion: 
+    AppIdChat: 
+    AppIdVoice: 
+    AppVersion: 
+    UseNameServer: 1
+    FixedRegion: 
+    Server: 
+    Port: 0
+    ProxyServer: 
+    Protocol: 0
+    EnableProtocolFallback: 1
+    AuthMode: 0
+    EnableLobbyStatistics: 0
+    NetworkLogging: 1
+  ShowSettings: 1
+  AutoConnectAndJoin: 1
+  UseFusionAppSettings: 1
+  UseFusionAuthValues: 1
+--- !u!114 &1137757603
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137757598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1199893898, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1137757604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1137757598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91175dcc15224463780e01a8a98b1b60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  voiceDetection: 0
+  voiceDetectionThreshold: 0.01
+  voiceDetectionDelayMs: 500
+  interestGroup: 0
+  useTargetPlayers: 0
+  targetPlayers: 
+  debugEchoMode: 0
+  reliableMode: 0
+  encrypt: 0
+  transmitEnabled: 1
+  samplingRate: 24000
+  frameDuration: 40000
+  bitrate: 30000
+  sourceType: 0
+  microphoneType: 0
+  audioClip: {fileID: 0}
+  loopAudioClip: 1
+  recordingEnabled: 1
+  audioSessionParameters:
+    Category: 4
+    Mode: 1
+    CategoryOptions: 0800000004000000
+  editorAudioSessionPreset: 1
+  androidMicrophoneSettings:
+    EnableAEC: 1
+    EnableAGC: 1
+    EnableNS: 1
+  stopRecordingWhenPaused: 0
+  useOnAudioFilterRead: 0
+  useMicrophoneTypeFallback: 1
+  recordWhenJoined: 1
 --- !u!1 &1188744053
 GameObject:
   m_ObjectHideFlags: 0
@@ -14656,13 +14806,18 @@ MonoBehaviour:
   graphNetwork: {fileID: 0}
   generate2DController: {fileID: 0}
   graphSyncClient: {fileID: 0}
+  classroomFlow: {fileID: 0}
   waterRocketGraph: {fileID: 0}
   centerImage: {fileID: 0}
   generateButton: {fileID: 0}
   statusText: {fileID: 0}
   autoFindReferences: 1
   replaceGenerateButtonClick: 1
+  broadcastDirectServerResults: 1
+  restoreLatestSketchOnStart: 1
   requestTimeoutSeconds: 125
+  restoreTimeoutSeconds: 90
+  restorePollSeconds: 3
 --- !u!4 &2027575112
 Transform:
   m_ObjectHideFlags: 0
@@ -14753,6 +14908,56 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2030305467}
   m_CullTransparentMesh: 1
+--- !u!1 &2031659875
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2031659877}
+  - component: {fileID: 2031659876}
+  m_Layer: 0
+  m_Name: MvpReportPanelSyncRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2031659876
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2031659875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 685c198d72f955b47a6a703269be7de0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphNetworkManager: {fileID: 0}
+  classroomFlow: {fileID: 0}
+  reportPanel: {fileID: 0}
+  autoFindReferences: 1
+  broadcastLocalReportOpen: 1
+  pollIntervalSeconds: 0.2
+--- !u!4 &2031659877
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2031659875}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2050112133
 GameObject:
   m_ObjectHideFlags: 0
@@ -15254,3 +15459,5 @@ SceneRoots:
   - {fileID: 2027575112}
   - {fileID: 2002075751}
   - {fileID: 1019133364}
+  - {fileID: 2031659877}
+  - {fileID: 729180024}

--- a/Assets/01_Prefabs/Lobby/Player 4.prefab
+++ b/Assets/01_Prefabs/Lobby/Player 4.prefab
@@ -63,8 +63,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -93,8 +93,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 57
     m_Right: 9
@@ -119,8 +119,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_HorizontalFit: 2
   m_VerticalFit: 0
 --- !u!1 &675405097479795622
@@ -178,8 +178,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -292,8 +292,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_RenderShadows: 1
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
@@ -382,8 +382,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -412,8 +412,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
   m_MinWidth: 135
   m_MinHeight: 135
@@ -434,7 +434,6 @@ GameObject:
   - component: {fileID: 907791514735785240}
   - component: {fileID: 6356230599437807149}
   - component: {fileID: 7589851312190435785}
-  - component: {fileID: 3969864070245736095}
   m_Layer: 5
   m_Name: VOICE LEVEL
   m_TagString: Untagged
@@ -498,8 +497,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 0
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -521,34 +520,13 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &3969864070245736095
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2786375474699547514}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 675fc8ef78e2709488a0c13c9543dfe0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  bar1: {fileID: 8052698093592097087}
-  bar2: {fileID: 8107685527193286628}
-  bar3: {fileID: 7352460544595436742}
-  micOnIcon: {fileID: 5753773127135096521}
-  micOffIcon: {fileID: 1899101299567486487}
-  source: {fileID: 8946310488987050346}
-  th1: 0.1
-  th2: 0.3
-  th3: 0.6
 --- !u!1 &3554147005395343259
 GameObject:
   m_ObjectHideFlags: 0
@@ -560,7 +538,6 @@ GameObject:
   - component: {fileID: 790646390069488433}
   - component: {fileID: 4653034407119099621}
   - component: {fileID: 4157136635425565018}
-  - component: {fileID: 4808127163493742242}
   m_Layer: 0
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -642,8 +619,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -726,19 +703,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 4653034407119099621}
   m_maskType: 0
---- !u!114 &4808127163493742242
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3554147005395343259}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 47e451e1b64cc1b4b9051f19e0a56088, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  cameraTransform: {fileID: 0}
 --- !u!1 &3740900481864370909
 GameObject:
   m_ObjectHideFlags: 0
@@ -795,8 +759,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -886,8 +850,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
   m_MinWidth: 150
   m_MinHeight: -1
@@ -951,8 +915,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -989,6 +953,7 @@ GameObject:
   - component: {fileID: 7777000000000001001}
   - component: {fileID: 7777000000000002001}
   - component: {fileID: 7777000000000002002}
+  - component: {fileID: 3567302812849844629}
   m_Layer: 2
   m_Name: Player 4
   m_TagString: Untagged
@@ -1026,8 +991,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   SortKey: 2742984706
   ObjectInterest: 1
   Flags: 262145
@@ -1036,11 +1001,12 @@ MonoBehaviour:
   - {fileID: 3556351412152933350}
   - {fileID: 4457432579912392283}
   - {fileID: 3299013394198058777}
+  - {fileID: 7777000000000001001}
+  - {fileID: 7777000000000002001}
+  - {fileID: 3567302812849844629}
   - {fileID: 8892457148952465748}
   - {fileID: 5155273774042238179}
   - {fileID: 5708393112189265745}
-  - {fileID: 7777000000000001001}
-  - {fileID: 7777000000000002001}
   ForceRemoteRenderTimeframe: 0
 --- !u!114 &3556351412152933350
 MonoBehaviour:
@@ -1052,8 +1018,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 158639473, guid: e725a070cec140c4caffb81624c8c787, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _stateAuthorityChangeErrorCorrectionDelta: 0
   SyncScale: 0
   SyncParent: 0
@@ -1069,8 +1035,8 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 81eb1c386a0b7bf4d95ceea5008685a5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   mode: 0
   speakerAudio: {fileID: 1300419807030283483}
   recorder: {fileID: 0}
@@ -1087,8 +1053,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e8168619eb006db4eb1139bf318174ee, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   MeshRenderer: {fileID: 0}
   nameDisplayTMP: {fileID: 7892826706350949090}
   readyButton: {fileID: 0}
@@ -1114,8 +1080,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: de0c838257a759e4482942260c6fbb13, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &8946310488987050346
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1126,8 +1092,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 532989e96bdbb464789738a791cb1d20, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   smoothTime: 0.05
   level01: 0
 --- !u!114 &7777000000000001001
@@ -1140,8 +1106,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 54f66ae763a444ea812298f3f14443a6, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   localCameraReference: {fileID: 0}
   explicitLocalCamera: {fileID: 0}
   centerEyeObjectName: CenterEyeAnchor
@@ -1149,6 +1115,14 @@ MonoBehaviour:
   positionThreshold: 0.01
   rotationThreshold: 0.5
   fallbackFieldOfView: 60
+  _SharedCameraPosition: {x: 0, y: 0, z: 0}
+  _SharedCameraRotation: {x: 0, y: 0, z: 0, w: 0}
+  _SharedFieldOfView: 0
+  _PoseReady:
+    _value: 0
+  _PoseRevision: 0
+  _IsSharingView:
+    _value: 0
 --- !u!114 &7777000000000002001
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1159,11 +1133,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8d1b7f15d70eda54ab8304a1089b9130, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   sendRate: 20
   positionThreshold: 0.003
   handScanInterval: 0.5
+  enableMockHandsForDesktopTest: 0
+  mockHandsCommandLineArg: -presenterViewMockHands
+  _LeftHandTracked:
+    _value: 0
+  _RightHandTracked:
+    _value: 0
+  _PoseRevision: 0
 --- !u!114 &7777000000000002002
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1174,13 +1155,25 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9b92f27c66cf4224b9b830c9d98ac765, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   jointRadius: 0.018
   palmRadius: 0.026
   boneRadius: 0.007
   followSpeed: 28
   handColor: {r: 0.58, g: 0.58, b: 0.58, a: 0.92}
+--- !u!114 &3567302812849844629
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3937044470431379454}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6376dd7fc23b3764483a7349b58502e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4494516961612150461
 GameObject:
   m_ObjectHideFlags: 0
@@ -1253,8 +1246,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 0
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -1276,8 +1269,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -1339,8 +1332,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1369,8 +1362,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
   m_MinWidth: 30
   m_MinHeight: 30
@@ -1435,8 +1428,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
@@ -1465,8 +1458,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dca0c2b566dd5d54a8223cc8c2312d7e, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   targetRect: {fileID: 6960015702216346169}
   baseTargetWidth: 388.44
 --- !u!1 &5540236434167070287
@@ -1518,8 +1511,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreLayout: 1
   m_MinWidth: -1
   m_MinHeight: -1
@@ -1584,8 +1577,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1614,8 +1607,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
   m_MinWidth: 135
   m_MinHeight: 135
@@ -1718,8 +1711,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_RenderShadows: 1
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
@@ -1807,8 +1800,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1882,8 +1875,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1958,8 +1951,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
@@ -1988,8 +1981,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dca0c2b566dd5d54a8223cc8c2312d7e, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   targetRect: {fileID: 6960015702216346169}
   baseTargetWidth: 388.44
 --- !u!1 &9143183624405159722
@@ -2048,8 +2041,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
@@ -2078,8 +2071,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dca0c2b566dd5d54a8223cc8c2312d7e, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   targetRect: {fileID: 6960015702216346169}
   baseTargetWidth: 388.44
 --- !u!1001 &1389607860092504711
@@ -2168,7 +2161,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5899714176622387359, guid: 0dfe8d97202406e4b86e4a51f0805d40, type: 3}
       propertyPath: m_Source
-      value:
+      value: 
       objectReference: {fileID: 412044652712789455}
     - target: {fileID: 5899714176622387359, guid: 0dfe8d97202406e4b86e4a51f0805d40, type: 3}
       propertyPath: m_Enabled
@@ -2176,7 +2169,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5899714176622387359, guid: 0dfe8d97202406e4b86e4a51f0805d40, type: 3}
       propertyPath: m_Speaker
-      value:
+      value: 
       objectReference: {fileID: 3866699184826131118}
     - target: {fileID: 6821967783461365837, guid: 0dfe8d97202406e4b86e4a51f0805d40, type: 3}
       propertyPath: m_Name
@@ -2255,12 +2248,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6fb6c58e9dfb923479031eba64551aaa, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   source: {fileID: 8946310488987050346}
   headMesh: {fileID: 2570617485859632615}
   mouthBlendShapeIndex: 0
   maxMouthOpen: 100
+  speakingThreshold: 0.08
+  remoteSmoothSpeed: 12
+  _NetworkVoiceLevel: 0
+  _IsSpeaking:
+    _value: 0
 --- !u!114 &8532099507341742209
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2271,8 +2269,8 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa392b809b089674e82ce792ca5f7dbb, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_HeadTransform: {fileID: 872033728565909184}
   m_TorsoParentTransform: {fileID: 132705174975771766}
   m_HeadVisualsRoot: {fileID: 132705174975771766}
@@ -2290,8 +2288,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 19fea4ec09536d4498606b9bd7be39cb, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   characterHead: {fileID: 872033728565909184}
   characterBody: {fileID: 6683540413520560139}
   rotateThreshold: 30
@@ -2310,8 +2308,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 649355f74f76d294bacbe193206bf543, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &7651750081741706803
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2400,5 +2398,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dd7fea91fe63f4e1b884ef1e16a975c3, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/02_Scripts/Graph/Server/Generate3DController.cs
+++ b/Assets/02_Scripts/Graph/Server/Generate3DController.cs
@@ -94,6 +94,33 @@ public class Generate3DController : MonoBehaviour
         _modelParent = parent;
     }
 
+    // 마지막으로 화면에 올린 GLB 주소. 같은 주소를 다시 받으면 무시한다.
+    private string _lastShownModelUrl;
+
+    /// <summary>
+    /// 남이 만든 모델을 그대로 띄운다.
+    /// HandleModelGenerated 는 "내가 요청한 건"(_pendingJobId)만 통과시키므로,
+    /// 다른 참가자의 결과를 반영하려면 이 진입점이 따로 필요하다.
+    /// 서버에 다시 요청하지 않고 받은 주소를 내려받기만 한다(중복 과금 없음).
+    /// </summary>
+    public void ShowSharedModel(string modelUrl, string assetId = null)
+    {
+        if (string.IsNullOrWhiteSpace(modelUrl))
+            return;
+
+        if (string.Equals(_lastShownModelUrl, modelUrl, System.StringComparison.Ordinal))
+            return;
+
+        if (!string.IsNullOrEmpty(assetId))
+            _modelUrlBySourceAsset[assetId] = modelUrl;
+
+        _lastShownModelUrl = modelUrl;
+        StopGenerationTimeout();
+        _pendingJobId = null;
+        SetStatus("3D 모델을 불러오는 중...");
+        StartCoroutine(LoadAndShow(modelUrl));
+    }
+
     // ─────────────────────────────────────────────
     // 생명주기 / 구독
     // ─────────────────────────────────────────────
@@ -269,6 +296,9 @@ public class Generate3DController : MonoBehaviour
         // 원본 2D → GLB 매핑을 남겨 다음 요청 때 API 를 건너뛴다.
         if (!string.IsNullOrEmpty(_pendingSourceAssetId))
             _modelUrlBySourceAsset[_pendingSourceAssetId] = result.ModelUrl;
+
+        // 공유 경로로 같은 주소가 되돌아와도 다시 내려받지 않도록 남겨 둔다.
+        _lastShownModelUrl = result.ModelUrl;
 
         SetStatus("3D 모델을 불러오는 중...");
         StartCoroutine(LoadAndShow(result.ModelUrl));

--- a/Assets/02_Scripts/Lobby/GraphNetworkManager.cs
+++ b/Assets/02_Scripts/Lobby/GraphNetworkManager.cs
@@ -35,6 +35,8 @@ public class GraphNetworkManager : NetworkBehaviour
     public event Action<int, string, PlayerRef> Generated3DStartReceived;
     public event Action<PlayerRef> Generated3DStartRejected;
     public event Action<int> Generated3DFinishedReceived;
+    // 완성된 GLB 주소. 2D 의 Generated2DServerImageReceived 와 같은 역할이다.
+    public event Action<int, string, string, string> Generated3DModelReceived;
     public event Action<PlayerRef> ReportPanelShowReceived;
 
     private readonly Dictionary<string, PlayerRef> lockCache = new Dictionary<string, PlayerRef>();
@@ -494,6 +496,58 @@ public class GraphNetworkManager : NetworkBehaviour
             RPC_RequestGenerated3DFinish(version);
     }
 
+    /// <summary>
+    /// 내가 요청해서 완성된 GLB 주소를 방 전체에 알린다.
+    /// 이게 없으면 3D 는 "누가 시작했다/끝났다" 만 오가고 결과물은 만든 사람만 본다.
+    /// </summary>
+    public void RequestGenerated3DModel(
+        int version,
+        string assetId,
+        string mimeType,
+        string modelUrl)
+    {
+        if (!IsReadyForRpc || string.IsNullOrWhiteSpace(modelUrl))
+            return;
+
+        if (CanBroadcast)
+            FinishGenerated3DWithModelAsAuthority(
+                version,
+                Safe(assetId),
+                Safe(mimeType),
+                Safe(modelUrl));
+        else
+            RPC_RequestGenerated3DModel(
+                version,
+                Safe(assetId),
+                Safe(mimeType),
+                Safe(modelUrl));
+    }
+
+    /// <summary>
+    /// 생성 절차를 거치지 않고 이미 알고 있는 GLB 주소를 공유한다
+    /// (늦게 들어온 사람에게 현재 모델을 맞춰 줄 때).
+    /// </summary>
+    public void RequestGenerated3DModelSnapshot(
+        string assetId,
+        string mimeType,
+        string modelUrl)
+    {
+        if (!IsReadyForRpc || string.IsNullOrWhiteSpace(modelUrl))
+            return;
+
+        if (CanBroadcast)
+            RPC_BroadcastGenerated3DModel(
+                0,
+                Safe(assetId),
+                Safe(mimeType),
+                Safe(modelUrl));
+        else
+            RPC_RequestGenerated3DModelSnapshot(
+                Safe(assetId),
+                Safe(mimeType),
+                Safe(modelUrl));
+    }
+
     public void RequestReportPanelShow()
     {
         if (!IsReadyForRpc)
@@ -794,6 +848,46 @@ public class GraphNetworkManager : NetworkBehaviour
     private void RPC_BroadcastGenerated3DFinish(int version)
     {
         Generated3DFinishedReceived?.Invoke(version);
+    }
+
+    [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
+    private void RPC_RequestGenerated3DModel(
+        int version,
+        string assetId,
+        string mimeType,
+        string modelUrl)
+    {
+        FinishGenerated3DWithModelAsAuthority(version, assetId, mimeType, modelUrl);
+    }
+
+    [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
+    private void RPC_RequestGenerated3DModelSnapshot(
+        string assetId,
+        string mimeType,
+        string modelUrl)
+    {
+        if (!HasStateAuthority || string.IsNullOrWhiteSpace(modelUrl))
+            return;
+
+        RPC_BroadcastGenerated3DModel(
+            0,
+            Safe(assetId),
+            Safe(mimeType),
+            Safe(modelUrl));
+    }
+
+    [Rpc(RpcSources.StateAuthority, RpcTargets.All)]
+    private void RPC_BroadcastGenerated3DModel(
+        int version,
+        string assetId,
+        string mimeType,
+        string modelUrl)
+    {
+        Generated3DModelReceived?.Invoke(
+            version,
+            Safe(assetId),
+            Safe(mimeType),
+            Safe(modelUrl));
     }
 
     [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
@@ -1141,6 +1235,23 @@ public class GraphNetworkManager : NetworkBehaviour
             generated3DVersion,
             Safe(designJson),
             safeRequester);
+    }
+
+    private void FinishGenerated3DWithModelAsAuthority(
+        int version,
+        string assetId,
+        string mimeType,
+        string modelUrl)
+    {
+        if (!HasStateAuthority || !IsCurrentGenerated3DVersion(version))
+            return;
+
+        generated3DInProgress = false;
+        RPC_BroadcastGenerated3DModel(
+            version,
+            Safe(assetId),
+            Safe(mimeType),
+            Safe(modelUrl));
     }
 
     private void FinishGenerated3DAsAuthority(int version)

--- a/Assets/02_Scripts/Lobby/MvpGenerated3DModelSync.cs
+++ b/Assets/02_Scripts/Lobby/MvpGenerated3DModelSync.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using Fusion;
+using TMPro;
+using UnityEngine;
+
+/// <summary>
+/// 서버(Meshy)가 만든 GLB 를 방 전체가 같이 보게 만든다.
+///
+/// 이름이 비슷한 MvpGenerated3DSync 와는 하는 일이 다르다.
+///   - MvpGenerated3DSync      : 디자인 값으로 로컬 목업 로켓(MvpRocket3DStage)을 만들어 띄운다.
+///   - MvpGenerated3DModelSync : 서버가 실제로 만든 GLB 주소를 돌려 같은 모델을 띄운다.
+///
+/// 기존에는 3D 에 대해 "누가 시작했다 / 끝났다" 만 오갔고 완성된 GLB 주소를 돌리는
+/// 통로가 없어서, Meshy 결과물은 요청한 사람에게만 보였다.
+/// (2D 에는 Generated2DServerImageReceived 가 있는데 3D 에는 대응되는 것이 없었다)
+///
+/// 서버에 다시 요청하지 않고 이미 받은 주소만 돌리므로 중복 과금이 없다.
+/// </summary>
+[DefaultExecutionOrder(230)]
+public class MvpGenerated3DModelSync : MonoBehaviour
+{
+    private const BindingFlags PrivateInstanceFlags =
+        BindingFlags.Instance | BindingFlags.NonPublic;
+
+    [Header("References")]
+    [SerializeField] private GraphNetworkManager graphNetwork;
+    [SerializeField] private Generate3DController generate3DController;
+    [SerializeField] private GraphSyncClient graphSyncClient;
+    [SerializeField] private MvpClassroomFlow classroomFlow;
+    [SerializeField] private TMP_Text statusText;
+
+    [Header("Options")]
+    [SerializeField] private bool autoFindReferences = true;
+    [SerializeField] private bool broadcastDirectServerResults = true;
+
+    private GraphNetworkManager subscribedGraphNetwork;
+    private GraphSyncClient subscribedGraphSyncClient;
+
+    private float nextResolveTime;
+    private string lastBroadcastModelUrl;
+
+    private void OnEnable()
+    {
+        ResolveReferences();
+        RefreshBindings();
+    }
+
+    private IEnumerator Start()
+    {
+        yield return null;
+        ResolveReferences();
+        RefreshBindings();
+    }
+
+    private void Update()
+    {
+        if (!autoFindReferences || Time.unscaledTime < nextResolveTime)
+            return;
+
+        nextResolveTime = Time.unscaledTime + 1f;
+        ResolveReferences();
+        RefreshBindings();
+    }
+
+    private void OnDisable()
+    {
+        UnbindGraphNetwork();
+        UnbindGraphSyncClient();
+    }
+
+    /// <summary>
+    /// 서버에서 내 3D 결과가 도착했다. 방 전체에 주소를 돌린다.
+    /// </summary>
+    private void HandleServerModelFromGraphSync(GraphSyncClient.Model3DResult result)
+    {
+        string modelUrl = result.ModelUrl;
+        if (!broadcastDirectServerResults ||
+            string.IsNullOrWhiteSpace(modelUrl) ||
+            graphNetwork == null ||
+            !graphNetwork.IsRpcReady ||
+            string.Equals(lastBroadcastModelUrl, modelUrl, StringComparison.Ordinal))
+            return;
+
+        lastBroadcastModelUrl = modelUrl;
+        graphNetwork.RequestGenerated3DModelSnapshot(
+            result.AssetId,
+            result.MimeType,
+            modelUrl);
+    }
+
+    /// <summary>
+    /// 방에서 GLB 주소가 왔다. 만든 사람이 아니어도 같은 모델을 띄운다.
+    /// 보낸 본인은 Generate3DController 가 이미 같은 주소를 띄웠으므로 그쪽에서 걸러진다.
+    /// </summary>
+    private void HandleGenerated3DModel(
+        int version,
+        string assetId,
+        string mimeType,
+        string modelUrl)
+    {
+        if (string.IsNullOrWhiteSpace(modelUrl))
+            return;
+
+        // 되돌아온 내 결과를 다시 방송하지 않도록 기억해 둔다.
+        lastBroadcastModelUrl = modelUrl;
+
+        ResolveReferences();
+        if (generate3DController == null)
+        {
+            Debug.LogWarning(
+                "[MvpGenerated3DModelSync] Generate3DController 를 찾지 못해 공유된 3D 모델을 띄우지 못했습니다.");
+            return;
+        }
+
+        SetStatus("3D 모델을 불러오는 중...");
+        generate3DController.ShowSharedModel(modelUrl, assetId);
+    }
+
+    private void ResolveReferences()
+    {
+        if (!autoFindReferences)
+            return;
+
+        if (generate3DController == null)
+            generate3DController = FindFirstObjectByType<Generate3DController>();
+        if (graphSyncClient == null && generate3DController != null)
+            graphSyncClient = generate3DController.GetComponent<GraphSyncClient>();
+        if (graphSyncClient == null)
+            graphSyncClient = FindFirstObjectByType<GraphSyncClient>();
+        if (graphNetwork == null)
+            graphNetwork = FindFirstObjectByType<GraphNetworkManager>();
+        if (classroomFlow == null)
+            classroomFlow = FindFirstObjectByType<MvpClassroomFlow>();
+        if (statusText == null && classroomFlow != null)
+            statusText = GetPrivateField<TMP_Text>(classroomFlow, "_workspaceStatus");
+    }
+
+    private void RefreshBindings()
+    {
+        BindGraphNetwork();
+        BindGraphSyncClient();
+    }
+
+    private void BindGraphNetwork()
+    {
+        if (subscribedGraphNetwork == graphNetwork)
+            return;
+
+        UnbindGraphNetwork();
+
+        subscribedGraphNetwork = graphNetwork;
+        if (subscribedGraphNetwork != null)
+            subscribedGraphNetwork.Generated3DModelReceived += HandleGenerated3DModel;
+    }
+
+    private void UnbindGraphNetwork()
+    {
+        if (subscribedGraphNetwork == null)
+            return;
+
+        subscribedGraphNetwork.Generated3DModelReceived -= HandleGenerated3DModel;
+        subscribedGraphNetwork = null;
+    }
+
+    private void BindGraphSyncClient()
+    {
+        if (subscribedGraphSyncClient == graphSyncClient)
+            return;
+
+        UnbindGraphSyncClient();
+
+        subscribedGraphSyncClient = graphSyncClient;
+        if (subscribedGraphSyncClient != null)
+            subscribedGraphSyncClient.OnModel3DGenerated += HandleServerModelFromGraphSync;
+    }
+
+    private void UnbindGraphSyncClient()
+    {
+        if (subscribedGraphSyncClient == null)
+            return;
+
+        subscribedGraphSyncClient.OnModel3DGenerated -= HandleServerModelFromGraphSync;
+        subscribedGraphSyncClient = null;
+    }
+
+    private void SetStatus(string message)
+    {
+        if (string.IsNullOrEmpty(message))
+            return;
+
+        if (statusText != null)
+            statusText.text = message;
+        if (classroomFlow != null)
+            classroomFlow.SetWorkspaceMessage(message, MvpStudentUiFactory.Cyan);
+    }
+
+    private static T GetPrivateField<T>(object target, string fieldName)
+    {
+        if (target == null || string.IsNullOrEmpty(fieldName))
+            return default;
+
+        FieldInfo field = target.GetType().GetField(fieldName, PrivateInstanceFlags);
+        if (field == null)
+            return default;
+
+        object value = field.GetValue(target);
+        return value is T typed ? typed : default;
+    }
+}

--- a/Assets/02_Scripts/Lobby/MvpGenerated3DModelSync.cs.meta
+++ b/Assets/02_Scripts/Lobby/MvpGenerated3DModelSync.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a93f95e599674f744919710cf166a5fa


### PR DESCRIPTION
회의실(MVP_SH)에서 동기화가 빠져 있던 세 곳을 채웁니다.

## 1. 리포트 패널

`MvpReportPanelSync` 가 `mvp_js` 씬에만 붙어 있어 MVP_SH 에서는 리포트를 열어도 나만 봤습니다. MVP_SH 에도 얹었습니다. 참조를 자동으로 찾는 구조라 배선은 필요 없습니다.

## 2. 3D 모델

3D 는 "누가 시작했다 / 끝났다" 만 오가고 **완성된 GLB 주소를 돌리는 통로가 없어서**, 서버(Meshy)가 만든 모델은 요청한 사람에게만 보였습니다. 2D 에는 대응되는 RPC 가 있는데 3D 에는 없었습니다.

- `GraphNetworkManager` 에 GLB 주소를 돌리는 RPC 추가 (2D 와 동일 구조)
- `Generate3DController.ShowSharedModel()` — 남이 만든 모델을 띄우는 진입점. 기존 수신 경로는 내가 요청한 건(`_pendingJobId`)만 통과시킵니다. **서버에 재요청하지 않아 중복 과금이 없습니다.**
- `MvpGenerated3DModelSync` 신규 + MVP_SH 배선

> 이름이 비슷한 기존 `MvpGenerated3DSync` 는 하는 일이 다릅니다. 그쪽은 디자인 값으로 로컬 목업 로켓(`MvpRocket3DStage`)을 만드는 것이고 서버 GLB 와 무관합니다. 건드리지 않고 별도 컴포넌트로 두었습니다.

## 3. 음성

MVP_SH 에 Photon Voice 구성이 아예 없었습니다. 로비와 같은 구성으로 `Recorder` + `FusionVoiceClient` 를 얹고 `primaryRecorder` 를 연결했습니다.

그리고 Recorder/Speaker 를 네트워크에 묶어 주는 **`VoiceNetworkObject` 가 프로젝트 전체에서 한 번도 쓰이지 않고 있었습니다.** 이게 없으면 소리가 오가지 않아 아바타 프리팹(`Player 4`)에 추가했습니다. **같은 프리팹을 로비도 쓰므로 로비 음성에도 영향이 갑니다.**

프리팹에 죽은 스크립트 참조 두 개(`VOICE LEVEL`, `Text (TMP)`)가 있어 Unity 가 프리팹 저장 자체를 거부하고 있었습니다. 이 저장소에 한 번도 존재한 적 없는 GUID 라 되살릴 수 없어 제거했습니다. MonoBehaviour 45 → 44 개(−2 +1).

## 검증

플레이 모드에서 확인:

| 항목 | 결과 |
|---|---|
| `MvpReportPanelSync` | 살아 있음, `classroomFlow` 찾음 |
| `MvpGenerated3DModelSync` | 살아 있음, `generate3DController`·`graphSyncClient` 찾음 |
| `Recorder` | `TransmitEnabled = True` |
| `FusionVoiceClient` | `PrimaryRecorder` 연결됨 |
| 콘솔 에러 | 0개 |

`graphNetwork` 만 null 인데 `GraphNetworkManager` 는 Fusion 세션이 뜰 때 스폰되는 프리팹이라 에디터 단독 실행에서는 정상입니다. 두 컴포넌트 모두 1초마다 다시 찾습니다.

**실제 통화·모델 공유·리포트 동기화는 헤드셋 2대 검증이 필요합니다.** 배선과 초기화까지만 확인했습니다.