### PR TITLE
fix: 파트·하위 노드·3D가 다른 참가자에게 보이지 않던 문제

### DIFF
--- a/Assets/00_Scenes/MVP/Runtime/Core/MvpClassroomFlow.cs
+++ b/Assets/00_Scenes/MVP/Runtime/Core/MvpClassroomFlow.cs
@@ -1860,7 +1860,9 @@ public class MvpClassroomFlow : MonoBehaviour
     //
     // 자리는 mock 로켓(MvpRocket3DStage)과 동일하게 메인 보드 기준으로 잡는다. 카메라 기준으로
     // 두면 XR 에서 Camera.main 좌표가 실제 시점과 달라 시야 밖으로 나간다(실측 y=-1.46).
-    private Transform EnsureServerModelStage()
+    // 남이 만든 3D 가 공유돼 올 때 받는 쪽도 같은 자리에 받침을 세워야 하므로
+    // MvpGenerated3DModelSync 가 호출할 수 있게 공개한다.
+    public Transform EnsureServerModelStage()
     {
         if (_serverModelStage != null)
         {

--- a/Assets/00_Scenes/MVP/Runtime/XR/MvpGraphNetworkBridge.cs
+++ b/Assets/00_Scenes/MVP/Runtime/XR/MvpGraphNetworkBridge.cs
@@ -48,6 +48,9 @@ public class MvpGraphNetworkBridge : MonoBehaviour
         _graph.OnNodeRekeyed += HandleNodeRekeyed;
         _graph.OnEdgeRekeyed += HandleEdgeRekeyed;
         _graph.OnNodeActiveChanged += HandleNodeActiveChanged;
+        _graph.OnLocalNodeAdded += HandleLocalNodeAdded;
+        _graph.OnLocalNodeTextChanged += HandleLocalNodeTextChanged;
+        _graph.OnLocalEdgeAdded += HandleLocalEdgeAdded;
         _subscribed = true;
     }
 
@@ -63,6 +66,9 @@ public class MvpGraphNetworkBridge : MonoBehaviour
         _graph.OnNodeRekeyed -= HandleNodeRekeyed;
         _graph.OnEdgeRekeyed -= HandleEdgeRekeyed;
         _graph.OnNodeActiveChanged -= HandleNodeActiveChanged;
+        _graph.OnLocalNodeAdded -= HandleLocalNodeAdded;
+        _graph.OnLocalNodeTextChanged -= HandleLocalNodeTextChanged;
+        _graph.OnLocalEdgeAdded -= HandleLocalEdgeAdded;
         _subscribed = false;
     }
 
@@ -137,5 +143,36 @@ public class MvpGraphNetworkBridge : MonoBehaviour
     {
         if (!ShouldForward()) return;
         _network.RequestSetNodeActive(nodeId, active);
+    }
+
+    // ── 서버 등록 여부와 무관한 로컬 변경 ────────────────────────────
+    //
+    // 위의 On*Created 는 "서버에 보낼 것"이라 PART 는 아예 발행되지 않고,
+    // 자식 PROPERTY 는 부모가 서버 미등록이면 보류된다. 그 때문에 파트와
+    // 하위 노드가 상대 화면에 끝내 안 나타났다.
+    //
+    // 같은 노드를 두 경로로 보내게 되는데, 받는 쪽 ApplyCreateNode 가
+    // AddNode 실패(이미 존재)로 흡수하므로 중복은 문제가 되지 않는다.
+
+    private void HandleLocalNodeAdded(NodeData node)
+    {
+        if (!ShouldForward() || node == null) return;
+        _network.RequestCreateNode(node, node.parent_node_id ?? "");
+    }
+
+    private void HandleLocalNodeTextChanged(NodeData node)
+    {
+        if (!ShouldForward() || node == null) return;
+
+        // 상대가 아직 이 노드를 모를 수 있다(생성 시점에 세션이 아직 안 붙었던 경우).
+        // 생성부터 다시 보내면 받는 쪽에서 알아서 흡수한다.
+        _network.RequestCreateNode(node, node.parent_node_id ?? "");
+        _network.RequestUpdateNodeText(node.node_id, node.label, node.node_text);
+    }
+
+    private void HandleLocalEdgeAdded(EdgeData edge)
+    {
+        if (!ShouldForward() || edge == null) return;
+        _network.RequestCreateEdge(edge);
     }
 }

--- a/Assets/02_Scripts/Graph/GraphManager.cs
+++ b/Assets/02_Scripts/Graph/GraphManager.cs
@@ -102,6 +102,26 @@ public class GraphManager : MonoBehaviour
     // 브리지가 Fusion 으로 전파해 다른 참가자 화면의 초록선/흐림도 함께 바뀐다.
     public event Action<string, bool> OnNodeActiveChanged;
 
+    // ── 같은 방 참가자에게 보내기 위한 신호 ──────────────────────────
+    //
+    // 위의 OnNodeCreated / OnEdgeCreated 는 "서버에 보낼 것"을 뜻한다. 그래서
+    // 서버 사정으로 발행되지 않는 경우가 있다.
+    //   - PART 노드는 REST 로 따로 등록하므로 OnNodeCreated 를 아예 쏘지 않는다.
+    //   - 자식 PROPERTY 는 부모가 서버 미등록이면 발행을 보류한다.
+    // 그런데 같은 방 참가자에게는 서버 등록 여부와 상관없이 보여야 한다.
+    // (실기 확인: 파트도 하위 노드도 상대 화면에 끝내 안 나타났다)
+    //
+    // 그래서 로컬에서 그래프가 바뀌면 조건 없이 발행하는 신호를 따로 둔다.
+    // 원격 적용분은 브리지가 GraphNetworkManager.IsApplyingRemote 로 걸러낸다.
+    //
+    // AddNode/AddEdge 가 아니라 "생성이 완전히 끝난 지점"에서 발행한다.
+    // AddNode 직후에 발행하면, 뒤이은 AddEdge 가 규칙 위반으로 실패해 노드를
+    // 되돌릴 때(RequestCreatePropertyNode) 상대에게 유령 노드가 남는다.
+    // 서버 그래프 일괄 로드가 AddNode 를 직접 쓰는 것도 여기서 함께 걸러진다.
+    public event Action<NodeData> OnLocalNodeAdded;
+    public event Action<NodeData> OnLocalNodeTextChanged;
+    public event Action<EdgeData> OnLocalEdgeAdded;
+
     // ─────────────────────────────────────────────
     // 내부 상태
     // ─────────────────────────────────────────────
@@ -586,6 +606,9 @@ public class GraphManager : MonoBehaviour
         }
 
         ReflowAllSubtrees();
+        // 노드와 부모 엣지가 모두 자리를 잡은 뒤에 알린다(순서도 이대로 나가야 한다).
+        OnLocalNodeAdded?.Invoke(newNode);
+        OnLocalEdgeAdded?.Invoke(edge);
         return newNode.node_id;
     }
 
@@ -613,6 +636,7 @@ public class GraphManager : MonoBehaviour
             SpawnNodeView(newNode);
 
         ReflowAllSubtrees();
+        OnLocalNodeAdded?.Invoke(newNode);
         return newNode.node_id;
     }
 
@@ -639,6 +663,10 @@ public class GraphManager : MonoBehaviour
 
         node.label     = t;
         node.node_text = t;
+
+        // 아래 분기들은 서버 사정으로 중간에 return 할 수 있다(부모 미등록, ACK 대기 등).
+        // 같은 방 참가자에게는 그와 무관하게 글자가 보여야 하므로 여기서 먼저 알린다.
+        OnLocalNodeTextChanged?.Invoke(node);
 
         if (_serverKnownNodeIds.Contains(nodeId))
         {
@@ -882,6 +910,9 @@ public class GraphManager : MonoBehaviour
         if (locallyIssued)
             OnLocalPartNodeCreated?.Invoke(node.node_id, label, isGlobal, node.Position);
 
+        // PART 는 서버 등록 경로가 따로라 OnNodeCreated 를 쏘지 않는다.
+        // 그래서 이걸 알리지 않으면 파트가 상대 화면에 영영 안 생긴다.
+        OnLocalNodeAdded?.Invoke(node);
         return node.node_id;
     }
 
@@ -896,6 +927,7 @@ public class GraphManager : MonoBehaviour
         if (!AddEdge(edge)) return false;
         SpawnEdgeView(edge);
         OnEdgeCreated?.Invoke(edge);
+        OnLocalEdgeAdded?.Invoke(edge);
         return true;
     }
 

--- a/Assets/02_Scripts/Lobby/GraphNetworkManager.cs
+++ b/Assets/02_Scripts/Lobby/GraphNetworkManager.cs
@@ -939,6 +939,33 @@ public class GraphNetworkManager : NetworkBehaviour
             bool changed = nodeCreated;
 
             NodeData appliedNode = nodeCreated ? node : graphManager.GetNode(safeNodeId);
+
+            // 이미 아는 노드로 다시 들어온 경우에도 글자는 반영한다.
+            // 보내는 쪽은 글자가 정해질 때 생성부터 다시 보내는데(상대가 아직
+            // 이 노드를 모를 수 있으므로), 여기서 흡수만 하고 끝내면 글자가
+            // 영영 안 붙는다. 텍스트 전용 RPC 는 잠금이 필요해 방금 만든
+            // 노드의 첫 글자가 막히는 경우가 있어 이 경로가 필요하다.
+            if (!nodeCreated && appliedNode != null)
+            {
+                string incomingLabel = Safe(label);
+                string incomingText = string.IsNullOrEmpty(description)
+                    ? incomingLabel
+                    : Safe(description);
+
+                if (!string.IsNullOrWhiteSpace(incomingLabel) &&
+                    appliedNode.label != incomingLabel)
+                {
+                    appliedNode.label = incomingLabel;
+                    changed = true;
+                }
+                if (!string.IsNullOrWhiteSpace(incomingText) &&
+                    appliedNode.node_text != incomingText)
+                {
+                    appliedNode.node_text = incomingText;
+                    changed = true;
+                }
+            }
+
             if (appliedNode != null && !string.IsNullOrWhiteSpace(safeParentNodeId))
             {
                 appliedNode.parent_node_id = safeParentNodeId;

--- a/Assets/02_Scripts/Lobby/MvpGenerated3DModelSync.cs
+++ b/Assets/02_Scripts/Lobby/MvpGenerated3DModelSync.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Fusion;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Networking;
 
 /// <summary>
 /// 서버(Meshy)가 만든 GLB 를 방 전체가 같이 보게 만든다.
@@ -34,12 +35,16 @@ public class MvpGenerated3DModelSync : MonoBehaviour
     [Header("Options")]
     [SerializeField] private bool autoFindReferences = true;
     [SerializeField] private bool broadcastDirectServerResults = true;
+    [SerializeField] private bool restoreLatestModelOnStart = true;
+    [SerializeField] private float restoreTimeoutSeconds = 60f;
+    [SerializeField] private float restorePollSeconds = 3f;
 
     private GraphNetworkManager subscribedGraphNetwork;
     private GraphSyncClient subscribedGraphSyncClient;
 
     private float nextResolveTime;
     private string lastBroadcastModelUrl;
+    private Coroutine restoreCoroutine;
 
     private void OnEnable()
     {
@@ -52,6 +57,7 @@ public class MvpGenerated3DModelSync : MonoBehaviour
         yield return null;
         ResolveReferences();
         RefreshBindings();
+        StartLatestModelRestore();
     }
 
     private void Update()
@@ -68,6 +74,134 @@ public class MvpGenerated3DModelSync : MonoBehaviour
     {
         UnbindGraphNetwork();
         UnbindGraphSyncClient();
+        StopLatestModelRestore();
+    }
+
+    // ── 놓친 3D 결과 따라잡기 ────────────────────────────────────────
+    //
+    // 3D 는 Meshy 때문에 1~2분이 걸린다. 그 사이 WS 가 끊기면 서버가 완료를
+    // 보낼 곳이 없어 결과가 그대로 사라진다.
+    // (실측 2026-08-15: 완료 6초 전 ws_closed → ws_send_to_user_skip → 유실)
+    //
+    // 생성물 자체는 서버에 남으므로 방에 들어올 때 한 번 확인한다.
+    // 앱을 다시 켠 경우와 늦게 합류한 참가자도 같이 해결된다.
+
+    private void StartLatestModelRestore()
+    {
+        if (!restoreLatestModelOnStart || restoreCoroutine != null)
+            return;
+
+        restoreCoroutine = StartCoroutine(RestoreLatestModelWhenReady());
+    }
+
+    private void StopLatestModelRestore()
+    {
+        if (restoreCoroutine == null)
+            return;
+
+        StopCoroutine(restoreCoroutine);
+        restoreCoroutine = null;
+    }
+
+    private IEnumerator RestoreLatestModelWhenReady()
+    {
+        float deadline = Time.unscaledTime + Mathf.Max(5f, restoreTimeoutSeconds);
+
+        while (Time.unscaledTime < deadline)
+        {
+            ResolveReferences();
+
+            // 이미 모델이 떠 있으면 건드리지 않는다(내가 방금 만든 경우).
+            if (generate3DController != null && generate3DController.HasModel)
+                break;
+
+            if (graphSyncClient == null ||
+                string.IsNullOrWhiteSpace(graphSyncClient.Host) ||
+                string.IsNullOrWhiteSpace(graphSyncClient.RoomId))
+            {
+                yield return new WaitForSecondsRealtime(
+                    Mathf.Max(0.5f, restorePollSeconds));
+                continue;
+            }
+
+            string url =
+                $"{ServerAddress.Http(graphSyncClient.Host)}/api/3d/latest/" +
+                UnityWebRequest.EscapeURL(graphSyncClient.RoomId);
+
+            using (UnityWebRequest request = UnityWebRequest.Get(url))
+            {
+                request.timeout = 15;
+                yield return request.SendWebRequest();
+
+                if (request.result != UnityWebRequest.Result.Success)
+                {
+                    Debug.LogWarning(
+                        "[MvpGenerated3DModelSync] 최신 3D 조회 실패: " +
+                        request.error + " (code=" + request.responseCode + ")");
+                    yield return new WaitForSecondsRealtime(
+                        Mathf.Max(0.5f, restorePollSeconds));
+                    continue;
+                }
+
+                string modelUrl = null;
+                string assetId = null;
+                try
+                {
+                    LatestModelResponseDto response =
+                        JsonUtility.FromJson<LatestModelResponseDto>(
+                            request.downloadHandler.text);
+                    if (response?.result != null)
+                    {
+                        modelUrl = response.result.model_url;
+                        assetId = response.result.asset_id;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogWarning(
+                        "[MvpGenerated3DModelSync] 최신 3D 응답 해석 실패: " +
+                        exception.Message);
+                }
+
+                if (!string.IsNullOrWhiteSpace(modelUrl))
+                {
+                    Debug.Log(
+                        "[MvpGenerated3DModelSync] 놓친 3D 결과를 서버에서 받아 띄웁니다.");
+                    HandleGenerated3DModel(0, assetId, string.Empty, modelUrl);
+
+                    // 같은 방 참가자에게도 알려 늦게 들어온 사람까지 맞춘다.
+                    if (broadcastDirectServerResults &&
+                        graphNetwork != null &&
+                        graphNetwork.IsRpcReady)
+                    {
+                        lastBroadcastModelUrl = modelUrl;
+                        graphNetwork.RequestGenerated3DModelSnapshot(
+                            assetId, string.Empty, modelUrl);
+                    }
+                    break;
+                }
+            }
+
+            // 아직 없으면(생성 중일 수 있다) 잠시 뒤 다시 본다.
+            yield return new WaitForSecondsRealtime(
+                Mathf.Max(0.5f, restorePollSeconds));
+        }
+
+        restoreCoroutine = null;
+    }
+
+    [Serializable]
+    private class LatestModelResponseDto
+    {
+        public LatestModelResultDto result;
+    }
+
+    [Serializable]
+    private class LatestModelResultDto
+    {
+        public string asset_id;
+        public string model_url;
+        public string mime_type;
     }
 
     /// <summary>
@@ -112,6 +246,15 @@ public class MvpGenerated3DModelSync : MonoBehaviour
             Debug.LogWarning(
                 "[MvpGenerated3DModelSync] Generate3DController 를 찾지 못해 공유된 3D 모델을 띄우지 못했습니다.");
             return;
+        }
+
+        // 받침대는 요청한 사람 쪽에서만 세워졌다(MvpClassroomFlow 가 로컬로 만든다).
+        // 받는 쪽도 같은 자리에 세워 두지 않으면 모델이 엉뚱한 곳에 붙는다.
+        if (classroomFlow != null)
+        {
+            Transform stage = classroomFlow.EnsureServerModelStage();
+            if (stage != null)
+                generate3DController.SetModelParent(stage);
         }
 
         SetStatus("3D 모델을 불러오는 중...");


### PR DESCRIPTION
헤드셋 실기에서 **파트, 하위 노드, 3D 모델과 그 받침대가 모두 상대 화면에 나타나지 않았습니다.** 원인이 각각 달랐습니다.

## 1. 파트와 하위 노드

`OnNodeCreated` 가 **"서버에 보낼 것"과 "남에게 보낼 것"을 겸하고** 있었습니다. 브리지가 이 이벤트를 듣는데, 서버 사정으로 발행되지 않는 경우가 있습니다.

- **PART** 는 REST 로 따로 등록하므로 `OnNodeCreated` 를 **아예 쏘지 않습니다.**
- **자식 PROPERTY** 는 부모가 서버 미등록이면 발행을 보류합니다.
  ```csharp
  if (!_serverKnownNodeIds.Contains(parentId)) {
      Debug.LogWarning("NODE_CREATE 보류: 부모 노드가 아직 서버 미등록");
      return;   // ← 피어 동기화까지 같이 죽음
  }
  ```

그래서 **서버 등록 여부와 무관한 로컬 변경 신호**를 따로 뒀습니다. 원격 적용분은 브리지가 `IsApplyingRemote` 로 걸러내므로 반사되지 않습니다.

신호는 `AddNode`/`AddEdge` 가 아니라 **"생성이 완전히 끝난 지점"** 에서 쏩니다. `AddNode` 직후에 쏘면, 뒤이은 `AddEdge` 가 규칙 위반으로 실패해 노드를 되돌릴 때(PART 밑에 PROPERTY) **상대에게 유령 노드가 남습니다.** 서버 그래프 일괄 로드가 재방송되는 것도 이 위치 덕에 함께 걸러집니다.

받는 쪽도 고쳤습니다. 이미 아는 노드로 다시 들어오면 **글자를 갱신**합니다. 텍스트 전용 RPC 는 잠금이 필요해 방금 만든 노드의 첫 글자가 막히는 경우가 있습니다.

## 2. 3D 모델과 받침대

받침대는 `MvpClassroomFlow` 가 로컬로만 만들어 요청한 사람에게만 보였습니다. 공유된 모델을 받을 때 받는 쪽도 같은 자리에 세우도록 `EnsureServerModelStage()` 를 열었습니다.

## 3. 생성 도중 연결이 끊기면 3D 결과가 사라지던 문제

```
00:55:19  3d_generation_started
00:56:51  ws_closed                      ← 완료 6초 전에 끊김
00:56:57  meshy SUCCEEDED, GLB 4.85MB 저장
00:56:57  ws_send_to_user_skip           ← 결과 폐기
```

생성물은 서버에 남으므로 방에 들어올 때 `GET /api/3d/latest/{room_id}` 로 따라잡습니다. **앱 재시작·늦은 합류도 함께 해결됩니다.**

> 서버 엔드포인트는 FastAPI-server 쪽 PR 로 함께 올립니다.

## 검증 (플레이 모드)

같은 조작(파트1 + 루트1 + 하위1 + 글자2 + 연결1)에서 **피어로 실제로 나가는 양**:

| | 고치기 전 | 고친 후 |
|---|---|---|
| 노드 | **1건** (`넓게`만) | **3건** |
| 엣지 | 1건 | 2건 |
| 글자 | **0건** | 2건 |

고치기 전에는 파트(날개)도 하위 노드(곡선형)도 아예 나가지 않았습니다.

나간 메시지만으로 그래프를 복원한 왕복 검사:

```
[보낸 쪽] 노드 3 / 엣지 2      [받은 쪽] 노드 3 / 엣지 2
   PART:날개                      PART:날개
   PROPERTY:곡선형                PROPERTY:곡선형
   PROPERTY:넓게                  PROPERTY:넓게
→ 라벨까지 완전 일치
```

3D 복구 경로는 실제로 유실됐던 방(`502284c0`)으로 조회해 모델 주소가 그대로 나오는 것과, 클라 JSON 해석이 있음/없음 양쪽을 올바로 처리하는 것을 확인했습니다.

**두 대 동시 접속 실기 검증은 아직입니다.** 로직 왕복까지만 확인했습니다.