### PR TITLE
fix: 다른 참가자가 만든 파트로 향하는 연결선이 안 보이던 문제

### DIFF
--- a/Assets/02_Scripts/Graph/Main/MainSketchView.cs
+++ b/Assets/02_Scripts/Graph/Main/MainSketchView.cs
@@ -55,6 +55,13 @@ public class MainSketchView : MonoBehaviour
         if (_graphManager == null || _subscribed) return;
         _graphManager.OnGraphChanged += Refresh;
         _subscribed = true;
+
+        // 꺼져 있는 동안의 변경은 통지를 못 받는다. 다른 참가자가 만든 PART 가
+        // 작업판이 닫혀 있을 때 도착하면, 판을 열어도 포트가 생기지 않아
+        // 그 PART 로 향하는 연결선이 영영 그려지지 않았다
+        // (선은 NodeView 와 PART 포트가 둘 다 있어야 그려진다).
+        // 그래서 켜질 때 현재 그래프로 한 번 맞춘다.
+        Refresh();
     }
 
     private void OnDisable()


### PR DESCRIPTION
## 문제

다른 참가자가 만든 파트에 노드를 연결해도 **선이 상대 화면에 나타나지 않았습니다.**

## 원인

`PROPERTY → PART` 연결선은 **`EdgeView` 로 그려지지 않습니다.** `SpawnEdgeView` 는 양 끝이 모두 NodeView 여야 하는데 PART 는 NodeView 가 없습니다.

```
실측: 원격 적용 후 _edgeViewMap = 0 (엣지 데이터는 있지만 EdgeView 는 없음)
```

이 선은 `MvpXrGraphLinkController` 가 매 프레임 **NodeView + PART 포트**를 찾아 직접 긋습니다. 즉 **포트가 없으면 선도 없습니다.**

PART 포트는 `MainSketchView.Refresh()` 가 만드는데:

```csharp
private void OnEnable() {
    _graphManager.OnGraphChanged += Refresh;   // 구독만 하고
    _subscribed = true;
}                                              // ← Refresh() 를 안 부름
```

작업판이 닫혀 있는 동안에는 `OnGraphChanged` 통지를 받지 못합니다. 다른 참가자가 만든 PART 가 그 사이에 도착하면 판을 열어도 포트가 생기지 않고, 그 PART 로 향하는 선이 영영 그려지지 않습니다.

## 고친 방법

`OnEnable` 에서 현재 그래프로 한 번 맞춥니다.

## 검증 상태

- 노드·엣지 **데이터** 양쪽 일치: 확인
- PROPERTY NodeView 가 받는 쪽에도 생성됨: 확인
- **선이 실제로 뜨는지: 미확인.** 작업판이 열린 정상 흐름에서 원격 파트가 도착하는 상황이 필요한데, 노드를 직접 주입하는 방식으로는 그 UI 상태가 재현되지 않습니다. 헤드셋 2대 검증이 필요합니다.