### PR TITLE
fix: 참가자가 만든 것과 새로 만든 이미지가 남에게 안 보이던 문제

### DIFF
--- a/Assets/00_Scenes/MVP/Runtime/XR/MvpNetworkSession.cs
+++ b/Assets/00_Scenes/MVP/Runtime/XR/MvpNetworkSession.cs
@@ -237,25 +237,64 @@ public class MvpNetworkSession : MonoBehaviour, INetworkRunnerCallbacks
         }
 
         // 3) GNM(스폰/원격 복제) 준비되면 로컬→네트워크 브리지 바인딩·활성화
-        GraphNetworkManager gnm = null;
-        t = 0f;
-        while (t < 8f)
-        {
-            gnm = FindFirstObjectByType<GraphNetworkManager>();
-            if (gnm != null) break;
-            t += Time.deltaTime;
-            yield return null;
-        }
+        //
+        // 예전에는 8초만 기다리고 포기했다. 그런데 마스터는 자기가 직접 스폰하므로
+        // 항상 성공하는 반면, 다른 참가자는 마스터가 씬 로드·아바타 스폰을 마치고
+        // GNM 을 스폰해 복제해 줄 때까지 기다려야 한다. Quest 에서 이 시간이 8초를
+        // 넘으면 그 사람만 브리지가 꺼진 채로 남고, 그가 만든 파트·노드·연결은
+        // 아무에게도 전달되지 않는다(받기만 한다).
+        //   실기 증상: "방장이 만든 건 모두에게 보이는데 방장이 아닌 사람이 만든 건
+        //   아무에게도 안 보인다"
+        // 그래서 포기하지 않고, 세션이 도는 동안 계속 지켜보다가 나타나면 붙인다.
+        yield return WatchGraphNetworkAndBind();
+    }
 
-        if (gnm != null && _bridge != null)
+    private IEnumerator WatchGraphNetworkAndBind()
+    {
+        GraphNetworkManager bound = null;
+        float nextNotice = 0f;
+
+        while (_runner != null && _runner.IsRunning)
         {
-            if (_graphManager == null)
-                _graphManager = FindFirstObjectByType<GraphManager>();
-            _bridge.Bind(_graphManager, gnm);
-            _bridge.SetActive(true);
-            BindNetworkNotices(gnm);
-            _sessionReadyTime = Time.unscaledTime;
-            Debug.Log("[MvpNetworkSession] 그래프 네트워크 브리지 활성화");
+            GraphNetworkManager gnm = FindFirstObjectByType<GraphNetworkManager>();
+
+            // 아직 안 왔으면 계속 기다린다(마스터가 늦게 스폰할 수 있다).
+            if (gnm == null)
+            {
+                if (bound != null)
+                {
+                    // 있던 것이 사라졌다 — 다시 붙일 때까지 내보내지 않는다.
+                    _bridge?.SetActive(false);
+                    bound = null;
+                    Debug.LogWarning(
+                        "[MvpNetworkSession] 그래프 네트워크 오브젝트가 사라져 브리지를 껐습니다.");
+                }
+                if (Time.unscaledTime >= nextNotice)
+                {
+                    nextNotice = Time.unscaledTime + 5f;
+                    Debug.Log(
+                        "[MvpNetworkSession] 그래프 네트워크 오브젝트를 기다리는 중입니다.");
+                }
+                yield return null;
+                continue;
+            }
+
+            // 새로 왔거나 교체됐으면 붙인다.
+            if (gnm != bound && _bridge != null)
+            {
+                if (_graphManager == null)
+                    _graphManager = FindFirstObjectByType<GraphManager>();
+                _bridge.Bind(_graphManager, gnm);
+                _bridge.SetActive(true);
+                BindNetworkNotices(gnm);
+                _sessionReadyTime = Time.unscaledTime;
+                bound = gnm;
+                Debug.Log(
+                    "[MvpNetworkSession] 그래프 네트워크 브리지 활성화" +
+                    (_runner.IsSharedModeMasterClient ? " (방장)" : " (참가자)"));
+            }
+
+            yield return null;
         }
     }
 

--- a/Assets/02_Scripts/Lobby/GraphNetworkManager.cs
+++ b/Assets/02_Scripts/Lobby/GraphNetworkManager.cs
@@ -980,6 +980,11 @@ public class GraphNetworkManager : NetworkBehaviour
                     changed |= EnsurePropertyParentEdge(safeParentNodeId, safeNodeId);
             }
 
+            // 이 노드를 기다리던 연결이 있으면 지금 붙인다.
+            // (서로 다른 참가자가 보낸 노드와 엣지는 도착 순서가 보장되지 않는다)
+            if (nodeCreated)
+                changed |= FlushPendingEdges();
+
             RenderIfChanged(changed);
             if (nodeCreated)
                 RemoteNodeCreated?.Invoke(node.node_id, Safe(createdBy));
@@ -1076,6 +1081,13 @@ public class GraphNetworkManager : NetworkBehaviour
         finally { _remoteApplyDepth--; }
     }
 
+    // 아직 못 붙인 엣지. 양쪽 노드가 다 와야 AddEdge 가 성공하는데, 서로 다른
+    // 참가자가 보낸 경우에는 도착 순서가 보장되지 않는다(A 가 만든 PART 보다
+    // B 가 만든 연결이 먼저 올 수 있다). 예전에는 그때 엣지가 그냥 사라졌다.
+    // 노드가 도착할 때마다 여기 있는 것들을 다시 시도한다.
+    private readonly List<EdgeData> pendingEdges = new List<EdgeData>();
+    private const int MaxPendingEdges = 256;
+
     private void ApplyCreateEdge(string edgeId, string fromNodeId, string toNodeId, string edgeType)
     {
         _remoteApplyDepth++;
@@ -1092,9 +1104,59 @@ public class GraphNetworkManager : NetworkBehaviour
             };
 
             bool changed = graphManager.AddEdge(edge);
+            if (!changed && graphManager.GetEdge(edge.edge_id) == null)
+                RememberPendingEdge(edge);
+
             RenderIfChanged(changed);
         }
         finally { _remoteApplyDepth--; }
+    }
+
+    private void RememberPendingEdge(EdgeData edge)
+    {
+        if (edge == null) return;
+
+        foreach (EdgeData pending in pendingEdges)
+        {
+            if (pending != null && pending.edge_id == edge.edge_id)
+                return;
+        }
+
+        if (pendingEdges.Count >= MaxPendingEdges)
+            pendingEdges.RemoveAt(0);
+
+        pendingEdges.Add(edge);
+    }
+
+    // 노드가 새로 들어온 뒤 호출한다. 붙는 것만 붙이고 나머지는 남겨 둔다.
+    private bool FlushPendingEdges()
+    {
+        if (pendingEdges.Count == 0 || graphManager == null)
+            return false;
+
+        bool changed = false;
+        for (int i = pendingEdges.Count - 1; i >= 0; i--)
+        {
+            EdgeData edge = pendingEdges[i];
+            if (edge == null)
+            {
+                pendingEdges.RemoveAt(i);
+                continue;
+            }
+
+            if (graphManager.GetEdge(edge.edge_id) != null)
+            {
+                pendingEdges.RemoveAt(i);
+                continue;
+            }
+
+            if (graphManager.AddEdge(edge))
+            {
+                pendingEdges.RemoveAt(i);
+                changed = true;
+            }
+        }
+        return changed;
     }
 
     private void ApplyDeleteEdge(string edgeId)
@@ -1207,12 +1269,26 @@ public class GraphNetworkManager : NetworkBehaviour
         string mimeType,
         string imgUrl)
     {
-        if (!HasStateAuthority || !IsCurrentGenerated2DVersion(version))
+        if (!HasStateAuthority)
             return;
 
-        generated2DInProgress = false;
+        // 버전이 안 맞아도 이미지를 버리지 않는다.
+        //
+        // 예전에는 IsCurrentGenerated2DVersion 이 false 면 그냥 return 했다.
+        // 그런데 그 전에 Finish 가 한 번이라도 들어오면(컨트롤러가 생성을
+        // 시작하지 못했거나 타임아웃) generated2DInProgress 가 false 가 되어,
+        // 뒤늦게 도착한 진짜 이미지가 조용히 폐기됐다.
+        // 그 결과 요청한 사람만(자기 WS 로 따로 받으므로) 진짜 그림을 보고
+        // 나머지는 시작할 때 띄운 목업이 그대로 남았다.
+        //   실기 증상: "만든 사람한테만 보이고 나머지는 목업"
+        //
+        // 진행 중이던 건이면 그 버전으로, 아니면 스냅샷(0)으로 알린다.
+        bool matchesCurrent = IsCurrentGenerated2DVersion(version);
+        if (matchesCurrent)
+            generated2DInProgress = false;
+
         RPC_BroadcastGenerated2DServerImage(
-            version,
+            matchesCurrent ? version : 0,
             Safe(assetId),
             Safe(mimeType),
             Safe(imgUrl));

--- a/Assets/02_Scripts/Lobby/MvpGenerated2DSync.cs
+++ b/Assets/02_Scripts/Lobby/MvpGenerated2DSync.cs
@@ -224,7 +224,19 @@ public class MvpGenerated2DSync : MonoBehaviour
             !graphNetwork.IsRpcReady ||
             IsBusy ||
             string.Equals(lastBroadcastImageUrl, imgUrl, StringComparison.Ordinal))
+        {
+            // 왜 남에게 안 보내는지 남긴다. "내 화면에만 이미지가 뜬다"를
+            // 실기에서 추적하려면 이 지점의 판단이 필요하다.
+            Debug.LogWarning(
+                "[MvpGenerated2DSync] 2D 결과를 방에 알리지 않았습니다 — " +
+                "broadcast=" + broadcastDirectServerResults +
+                " graphNetwork=" + (graphNetwork != null) +
+                " rpcReady=" + (graphNetwork != null && graphNetwork.IsRpcReady) +
+                " busy=" + IsBusy +
+                " 같은주소=" + string.Equals(
+                    lastBroadcastImageUrl, imgUrl, StringComparison.Ordinal));
             return;
+        }
 
         lastBroadcastImageUrl = imgUrl;
         graphNetwork.RequestGenerated2DImageSnapshot(
@@ -239,7 +251,10 @@ public class MvpGenerated2DSync : MonoBehaviour
         string mimeType,
         string imgUrl)
     {
-        if (activeVersion > 0 && version != activeVersion)
+        // version 0 은 "지금 방의 그림은 이것"이라는 스냅샷이라 언제나 받는다.
+        // 예전에는 생성 중인 사람(activeVersion > 0)이 스냅샷을 전부 버려서,
+        // 늦게 도착한 진짜 이미지를 못 받고 목업이 남았다.
+        if (version > 0 && activeVersion > 0 && version != activeVersion)
             return;
 
         StopRequestTimeout();


### PR DESCRIPTION
실기에서 나온 두 증상의 원인 셋을 고칩니다.

> "방장이 만든 건 모두에게 보이는데 방장이 아닌 사람이 만든 건 아무에게도 안 보인다"
> "새로 만든 이미지가 모두에게 동기화되지 않는다"

## 1. 참가자만 브리지가 꺼진 채 남는다

`MvpNetworkSession` 이 `GraphNetworkManager` 를 **8초만 기다리고 포기**했습니다.

마스터는 자기가 직접 스폰하므로 항상 성공하지만, 다른 참가자는 마스터가 씬 로드·아바타 스폰을 마치고 GNM 을 스폰해 복제해 줄 때까지 기다려야 합니다. Quest 에서 이 시간이 8초를 넘으면 **그 사람만 브리지가 꺼진 채 남아, 그가 만든 것은 아무에게도 전달되지 않습니다**(받기만 합니다).

증상의 비대칭성과 정확히 일치합니다. 포기하지 않고 세션이 도는 동안 계속 지켜보다 나타나면 붙입니다. 로그에 `(방장)` / `(참가자)` 를 남겨 실기에서 바로 확인됩니다.

## 2. 완성된 2D 이미지가 조용히 버려진다

생성을 시작하면 **모든 참가자가 목업을 띄우고**, 진짜 이미지는 Fusion 방송으로만 교체됩니다. 요청한 사람은 자기 WS 로 따로 받으므로, **방송이 끊기면 요청자만 진짜 그림을 보고 나머지는 목업이 남습니다.**

그 방송이 두 곳에서 버려지고 있었습니다.

| 위치 | 조건 | 고침 |
|---|---|---|
| 방장 | `IsCurrentGenerated2DVersion` false → `return` | 버리지 않고 스냅샷(0)으로 방송 |
| 받는 쪽 | `activeVersion > 0` 이면 스냅샷(version 0) 전부 폐기 | version 0 은 항상 수용 |

`Finish` 가 한 번이라도 먼저 들어오면(컨트롤러가 생성을 시작 못 했거나 타임아웃) `generated2DInProgress` 가 false 가 되어 뒤늦게 도착한 이미지가 폐기됐습니다.

## 3. 연결이 노드보다 먼저 도착하면 영구 유실

엣지는 양쪽 노드가 다 있어야 붙는데, 실패하면 그냥 버리고 **재시도가 없었습니다.** 같은 사람이 만들면 순서가 지켜지지만, A 가 만든 파트에 B 가 연결하면 발신자가 달라 순서 보장이 없습니다.

못 붙인 엣지를 보관했다가 노드가 올 때 다시 붙입니다.

## 검증 (플레이 모드, 10항목 통과 / 실패 0)

```
[1] 보내는 쪽    PART 신호 3건 · 글자 2건 · 엣지 2건 · 포트 연결 성공
[2] 왕복         노드·엣지가 라벨까지 원본과 일치
[3] 순서 뒤바뀜  엣지 먼저 도착 → 보관 → 노드 도착 후 연결 복구
[4] 글자         이미 아는 노드로 재수신 시 라벨 갱신
[5] 2D           남의 생성 시작 → 목업 720x460 → 스냅샷 수신 → 진짜 1408x768
                 예전 판정식이 True(버림)였던 조건 그대로 통과 확인
```

콘솔 에러 0개. 서버도 API/터널이미지 200, 최신 3D 조회 정상, 최근 에러 없음.

**헤드셋 2대 실기 검증은 아직입니다.** 위는 에디터에서 함수를 직접 호출해 확인한 것이라, 참가자 브리지 활성화와 연결선이 실제로 그려지는지는 실기에서만 확정됩니다.