### PR TITLE
fix: 소켓이 닫힌 순간에 만든 노드가 서버에 영영 등록되지 않던 문제

### DIFF
--- a/Assets/02_Scripts/Graph/GraphManager.cs
+++ b/Assets/02_Scripts/Graph/GraphManager.cs
@@ -140,6 +140,14 @@ public class GraphManager : MonoBehaviour
     // (ACK 전 텍스트를 바꿔 재제출하면 서버에 노드가 이중 생성되는 것 방지). ApplyServerNodeId 성공 또는 RemoveNode 시 해제.
     private readonly HashSet<string> _pendingCreateNodeIds = new HashSet<string>();
 
+    // NODE_CREATE 를 언제 보냈는지. ACK 가 오면 _pendingCreateNodeIds 에서 빠지지만,
+    // 소켓이 끊겨 있었거나 응답이 유실되면 영영 남아 그 노드를 다시는 못 보낸다.
+    // (그 노드는 서버 미등록으로 남고, 자식과 연결까지 줄줄이 막힌다)
+    // 그래서 일정 시간이 지나도 등록이 안 되면 재요청을 허용한다.
+    private readonly Dictionary<string, float> _pendingCreateSentAt =
+        new Dictionary<string, float>();
+    private const float PendingCreateRetrySeconds = 12f;
+
     // Reflow 후 위치 변화가 이 값(제곱거리) 미만이면 이동으로 보지 않는다(불필요한 NODE_MOVE 억제).
     private const float ReflowMoveEpsilonSqr = 0.001f * 0.001f;
 
@@ -311,6 +319,7 @@ public class GraphManager : MonoBehaviour
         _graphData.nodes.RemoveAll(n => n.node_id == nodeId);
         _serverKnownNodeIds.Remove(nodeId);
         _pendingCreateNodeIds.Remove(nodeId);
+        _pendingCreateSentAt.Remove(nodeId);
         return true;
     }
 
@@ -676,10 +685,25 @@ public class GraphManager : MonoBehaviour
         }
 
         // 이미 생성 요청이 진행 중이면(ACK 대기) 중복 발행 금지 — 로컬 텍스트만 갱신된 채 유지한다.
+        // 다만 ACK 가 한참 안 오면(소켓이 끊겨 송신이 버려졌거나 응답 유실) 다시 보낸다.
+        // 그러지 않으면 그 노드는 영영 서버에 등록되지 않고, 자식과 연결까지 줄줄이 막힌다.
         if (_pendingCreateNodeIds.Contains(nodeId))
         {
-            Debug.Log($"[GraphManager] NODE_CREATE 재요청 무시: 이미 생성 진행 중(ACK 대기). node_id={nodeId}");
-            return;
+            float sentAt;
+            bool stale =
+                !_pendingCreateSentAt.TryGetValue(nodeId, out sentAt) ||
+                Time.unscaledTime - sentAt >= PendingCreateRetrySeconds;
+
+            if (!stale)
+            {
+                Debug.Log($"[GraphManager] NODE_CREATE 재요청 무시: 이미 생성 진행 중(ACK 대기). node_id={nodeId}");
+                return;
+            }
+
+            Debug.LogWarning(
+                $"[GraphManager] NODE_CREATE ACK 가 {PendingCreateRetrySeconds}초 넘게 오지 않아 다시 보냅니다. node_id={nodeId}");
+            _pendingCreateNodeIds.Remove(nodeId);
+            _pendingCreateSentAt.Remove(nodeId);
         }
 
         // 첫 제출 → 서버에 직접 생성. 부모는 이 노드의 PROPERTY 부모(루트면 없음).
@@ -695,6 +719,7 @@ public class GraphManager : MonoBehaviour
             //   전부 [NODE404] 로 거부됐다(퀘스트 실기 확인 — 주먹 제스처로 만든 루트 PROPERTY).
             //   서버가 해당 REST 를 추가하면 OnSubGraphRequested / SubmitRootNodeWithSubGraph 경로를 되살리면 된다.
             _pendingCreateNodeIds.Add(nodeId);
+            _pendingCreateSentAt[nodeId] = Time.unscaledTime;
             OnNodeCreated?.Invoke(nodeId, t, "", "", node.Position);
             return;
         }
@@ -707,6 +732,7 @@ public class GraphManager : MonoBehaviour
         // 자식 노드: 로컬 id 를 job_id 로 실어 NODE_CREATE 발행(서버가 node_id 발급). sub_graph_id 는 서버가 부모에서 유도하므로 빈 값.
         // 서버-known 표시/"+"(자식 추가) 활성화는 여기서 하지 않고 ACK(ApplyServerNodeId)에서 처리한다(낙관적 선반영 금지).
         _pendingCreateNodeIds.Add(nodeId);
+        _pendingCreateSentAt[nodeId] = Time.unscaledTime;
         OnNodeCreated?.Invoke(nodeId, t, parentId, "", node.Position);
     }
 
@@ -786,6 +812,7 @@ public class GraphManager : MonoBehaviour
         _serverKnownNodeIds.Remove(jobId);
         _serverKnownNodeIds.Add(serverNodeId);
         _pendingCreateNodeIds.Remove(jobId);
+        _pendingCreateSentAt.Remove(jobId);
 
         // 3) NodeView 맵 키 이동 + 재바인드
         if (_nodeViewMap.TryGetValue(jobId, out NodeView view))

--- a/Assets/02_Scripts/Graph/Server/GraphSyncClient.cs
+++ b/Assets/02_Scripts/Graph/Server/GraphSyncClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Text;
 using Meta.Net.NativeWebSocket;   // Meta XR Voice SDK 번들 (autoReferenced). 별도 패키지 추가 시 GUID 충돌.
 using UnityEngine;
@@ -162,7 +163,10 @@ public class GraphSyncClient : MonoBehaviour
         _socket = new WebSocket(url);
 
         _socket.OnOpen += () =>
+        {
             Debug.Log($"[GraphSyncClient] WS 열림 → {url}");
+            FlushOutbox();
+        };
 
         _socket.OnError += (err) =>
             Debug.LogError($"[GraphSyncClient] WS 오류: {err}");
@@ -504,6 +508,19 @@ public class GraphSyncClient : MonoBehaviour
     // 송신 공통
     // ─────────────────────────────────────────────
 
+    // 소켓이 닫혀 있는 동안 못 보낸 메시지. 열리면 순서대로 내보낸다.
+    //
+    // 예전에는 그냥 버렸다. 그런데 NODE_CREATE 는 GraphManager 가 이미
+    // _pendingCreateNodeIds 에 넣은 뒤라 재요청이 영구히 막힌다.
+    //   → 그 노드는 서버에 영영 등록되지 않고(_serverKnownNodeIds 미포함),
+    //     자식 노드도 "부모가 서버 미등록"으로 전부 보류되며,
+    //     그 노드를 실은 연결로 2D 를 만들면 서버가 노드를 못 찾아 생성이 죽는다.
+    //   실측 2026-08-15: 연결이 가리킨 PROPERTY 가 nodes 테이블에 없어
+    //   "Input Snapshot에서 생성 Connection의 Node를 찾을 수 없습니다" 로 실패,
+    //   사용자 화면에는 목업만 남았다.
+    private readonly List<string> _outbox = new List<string>();
+    private const int MaxOutbox = 128;
+
     private void Send(string eventType, string json)
     {
         if (!_sendToServer)
@@ -513,11 +530,29 @@ public class GraphSyncClient : MonoBehaviour
         }
         if (_socket == null || _socket.State != WebSocketState.Open)
         {
-            Debug.LogWarning($"[GraphSyncClient] 송신 skip({eventType}): 소켓이 열려있지 않음(State={_socket?.State}).");
+            if (_outbox.Count >= MaxOutbox)
+                _outbox.RemoveAt(0);
+            _outbox.Add(json);
+            Debug.LogWarning(
+                $"[GraphSyncClient] 송신 보류({eventType}): 소켓이 열려있지 않음(State={_socket?.State}). " +
+                $"연결되면 보냅니다. 대기 {_outbox.Count}건");
             return;
         }
         Debug.Log($"[GraphSyncClient] 송신 {eventType}: {json}");
         _ = _socket.SendText(json);
+    }
+
+    private void FlushOutbox()
+    {
+        if (_outbox.Count == 0)
+            return;
+        if (_socket == null || _socket.State != WebSocketState.Open)
+            return;
+
+        Debug.Log($"[GraphSyncClient] 보류했던 {_outbox.Count}건을 보냅니다.");
+        for (int i = 0; i < _outbox.Count; i++)
+            _ = _socket.SendText(_outbox[i]);
+        _outbox.Clear();
     }
 
     // ─────────────────────────────────────────────


### PR DESCRIPTION
실기에서 **"연결한 노드로 2D 를 만들면 목업만 나온다"** 가 반복됐습니다. 서버 기록을 따라가니 원인이 클라이언트에 있었습니다.

## 증거

```
2026-08-15 06:43  room 65c977b8
  연결 요청  part = a0fa573f (전체)   → snapshot 에 있음
             node = b406fce1        → nodes 테이블에 없음
  서버가 아는 PROPERTY : 2개뿐, 둘 다 기본 라벨 "아이디어"
  받은 WS 이벤트       : NODE_MOVE 뿐, NODE_CREATE 는 한 건도 없음
```

## 원인

`GraphSyncClient.Send` 가 소켓이 열려 있지 않으면 메시지를 **그냥 버렸습니다.** 그런데 `NODE_CREATE` 는 `GraphManager` 가 이미 `_pendingCreateNodeIds` 에 넣은 뒤라 **재요청이 영구히 막힙니다.**

```csharp
// Send
if (_socket == null || _socket.State != WebSocketState.Open) return;   // 유실

// RequestSubmitNodeText
if (_pendingCreateNodeIds.Contains(nodeId)) return;                    // 영구 차단
```

그 결과:

1. 그 노드는 서버에 영영 등록되지 않음 (`_serverKnownNodeIds` 미포함)
2. 자식 노드도 "부모가 서버 미등록" 으로 전부 보류
3. 그 노드를 실은 연결로 2D 를 만들면 서버가 노드를 못 찾아 생성이 죽음
4. 클라이언트는 생성 시작 시점에 목업을 띄우므로 **사용자에게는 목업만 남음**

로그에 `ws_closed` 가 실제로 여러 번 찍혀 있었습니다.

## 고친 방법

| 파일 | 내용 |
|---|---|
| `GraphSyncClient` | 소켓이 닫혀 있으면 버리지 않고 **보관했다가 열릴 때 순서대로 전송** (최대 128건) |
| `GraphManager` | ACK 가 **12초** 넘게 오지 않으면 재요청 허용. 즉시 재시도는 그대로 막아 중복 생성은 안 남 |

## 검증 (플레이 모드)

| 항목 | 결과 |
|---|---|
| 소켓 닫힘 상태로 2건 송신 | 대기함 0 → 2 (유실 없음) |
| 닫힌 채 Flush 시도 | 2건 유지 |
| 같은 노드 즉시 재제출 | 차단됨 (발화 1회) |
| ACK 지연 후 재제출 | 재전송됨 (발화 2회) |
| 컴파일 | 에러 0개 |

## 남은 것

실행 로그로 다음 테스트의 원인 특정이 빨라집니다.

```
[GraphSyncClient] 송신 보류(NODE_CREATE): … 대기 N건    ← 뜨면 소켓 문제
[GraphManager] NODE_CREATE ACK 가 12초 넘게 …          ← 뜨면 서버 응답 문제
```

**헤드셋 2대 실기 검증은 아직입니다.**