### PR TITLE
fix: 다른 참가자가 만든 파트로 향하는 연결선이 안 보이던 문제

### DIFF
--- a/Assets/02_Scripts/Graph/GraphManager.cs
+++ b/Assets/02_Scripts/Graph/GraphManager.cs
@@ -834,6 +834,18 @@ public class GraphManager : MonoBehaviour
         Debug.Log($"[GraphManager] ApplyServerNodeId: job_id={jobId} → node_id={serverNodeId}");
         OnNodeRekeyed?.Invoke(jobId, serverNodeId, serverNodeText);
 
+        // 메인그래프 UI(PART/ALL 포트)를 다시 만들게 한다.
+        //
+        // 여기서 노드 id 와 엣지의 from/to 는 서버 id 로 바뀌지만, 포트는
+        // MainSketchView.Refresh 가 만들고 그건 OnGraphChanged 로만 돈다.
+        // 이 신호가 없으면 포트는 옛 id 를 그대로 들고 있어, PROPERTY→PART
+        // 연결선을 그릴 때 포트를 찾지 못한다(선은 매 프레임 노드뷰와 포트를
+        // id 로 맞춰 긋는다).
+        //   실기 증상: 노드는 보이는데 그 노드에서 파트로 가는 선만 안 보인다.
+        //   특히 다른 참가자가 만든 파트에서 나타난다 — 그쪽은 로컬 id 로 먼저
+        //   받고 나중에 rekey 를 받기 때문이다.
+        OnGraphChanged?.Invoke();
+
         // [2026-08-01] ACK 이전의 이동은 RequestMoveNode 에서 보류됐다(서버 미등록 → NODE404).
         //   이제 서버-known 이 됐으므로 현재 위치를 한 번 동기화한다.
         //   (NODE_CREATE 는 생성 시점 위치로 저장되므로, 그 뒤 옮긴 위치가 서버에 반영되지 않는 문제 보정.)

--- a/Assets/02_Scripts/Graph/Server/GraphSyncClient.cs
+++ b/Assets/02_Scripts/Graph/Server/GraphSyncClient.cs
@@ -303,6 +303,8 @@ public class GraphSyncClient : MonoBehaviour
                 return;
             }
             _graphManager.ApplyServerNodeId(result.job_id, result.node_id);
+            // 이 노드를 기다리느라 못 보낸 연결이 있으면 지금 보낸다.
+            FlushPendingEdges();
         }
         else
         {
@@ -450,6 +452,45 @@ public class GraphSyncClient : MonoBehaviour
     // 현재 서버 저장 표준은 반대인 PART → PROPERTY/REFERENCE이므로 WS 경계에서만 방향을 뒤집는다.
     // 서버 snapshot 수신 시에는 GraphSnapshotDto가 다시 로컬 표준으로 정규화한다.
     // 양 끝 노드가 서버-known 이 아니면 서버가 NODE404 → 송신 skip(로그).
+    // 양 끝 노드가 아직 서버-known 이 아니라 못 보낸 연결.
+    //
+    // 예전에는 그냥 버렸다. 그래서 노드가 나중에 등록돼도 그 연결은 영영 서버에
+    // 올라가지 않았고, 서버 edges 테이블이 빈 채로 남아 2D 생성이 그 연결을
+    // 반영하지 못했다(실측 2026-08-15 room f0d811f4: 연결을 걸었는데 edges 0건).
+    // 노드 ACK 가 올 때마다 다시 시도한다.
+    private readonly List<EdgeData> _pendingEdges = new List<EdgeData>();
+    private const int MaxPendingEdges = 128;
+
+    private void FlushPendingEdges()
+    {
+        if (_pendingEdges.Count == 0 || _graphManager == null)
+            return;
+
+        List<EdgeData> ready = new List<EdgeData>();
+        for (int i = _pendingEdges.Count - 1; i >= 0; i--)
+        {
+            EdgeData edge = _pendingEdges[i];
+            if (edge == null)
+            {
+                _pendingEdges.RemoveAt(i);
+                continue;
+            }
+            if (_graphManager.IsServerKnown(edge.from_node_id) &&
+                _graphManager.IsServerKnown(edge.to_node_id))
+            {
+                _pendingEdges.RemoveAt(i);
+                ready.Add(edge);
+            }
+        }
+
+        if (ready.Count == 0)
+            return;
+
+        Debug.Log($"[GraphSyncClient] 보류했던 연결 {ready.Count}건을 이제 보냅니다.");
+        for (int i = 0; i < ready.Count; i++)
+            HandleEdgeCreated(ready[i]);
+    }
+
     private void HandleEdgeCreated(EdgeData edge)
     {
         if (edge == null) return;
@@ -457,7 +498,21 @@ public class GraphSyncClient : MonoBehaviour
         if (_graphManager != null &&
             (!_graphManager.IsServerKnown(edge.from_node_id) || !_graphManager.IsServerKnown(edge.to_node_id)))
         {
-            Debug.LogWarning($"[GraphSyncClient] EDGE_CREATE 송신 skip: 양 끝 노드가 서버-known 이 아닙니다. from={edge.from_node_id} to={edge.to_node_id}");
+            bool known = false;
+            foreach (EdgeData pending in _pendingEdges)
+            {
+                if (pending != null && pending.edge_id == edge.edge_id) { known = true; break; }
+            }
+            if (!known)
+            {
+                if (_pendingEdges.Count >= MaxPendingEdges)
+                    _pendingEdges.RemoveAt(0);
+                _pendingEdges.Add(edge);
+            }
+
+            Debug.LogWarning(
+                $"[GraphSyncClient] EDGE_CREATE 보류: 양 끝 노드가 아직 서버-known 이 아닙니다. " +
+                $"from={edge.from_node_id} to={edge.to_node_id} 대기 {_pendingEdges.Count}건");
             return;
         }
 


### PR DESCRIPTION
> "노드는 보이는데 그 노드에서 파트로 가는 선만 안 보인다"

원인이 둘이었고, 둘 다 **파트 id 가 서버 id 로 바뀌는 시점(rekey)** 과 얽혀 있습니다.

## 1. rekey 뒤 파트 포트가 옛 id 를 그대로 든다

`ApplyServerNodeId` 는 노드 id 와 엣지의 from/to 를 서버 id 로 바꾸고 NodeView 도 다시 묶지만, **`OnGraphChanged` 를 발행하지 않았습니다.** 파트 포트는 `MainSketchView.Refresh()` 가 만들고 그건 `OnGraphChanged` 로만 돕니다.

```
엣지 to  → SERVER-PART-…   (새 id)
PartPort → LOCAL-PART-…    (옛 id)   ← 안 맞음
```

`PROPERTY → PART` 선은 매 프레임 **노드뷰와 포트를 id 로 맞춰** 긋습니다. 포트를 못 찾으니 **노드는 멀쩡히 보이고 선만 사라집니다.**

> 만든 사람은 처음부터 서버 id 로 파트를 만들어 어긋나지 않고, 받는 쪽만 로컬 id 로 먼저 받았다가 나중에 rekey 를 받습니다. 실기에서 본 비대칭이 이것입니다.

## 2. 연결이 서버에 영영 올라가지 않는다

`EDGE_CREATE` 는 양 끝 노드가 서버-known 이 아니면 송신을 건너뛰고 **버렸습니다.** 노드가 나중에 등록돼도 다시 보내지 않아, 서버 `edges` 테이블이 빈 채로 남고 2D 생성이 그 연결을 반영하지 못했습니다.

```
실측 2026-08-15 room f0d811f4 : 연결을 걸었는데 edges 0건
```

보류했다가 노드 ACK 가 올 때 다시 보냅니다.

## 검증 (플레이 모드)

| | 엣지 to | PartPort | 선 |
|---|---|---|---|
| rekey 전 | `LOCAL-PART-…` | `LOCAL-PART-…` | — |
| **rekey 후 (고치기 전)** | `SERVER-PART-…` | `LOCAL-PART-…` | **0개** |
| **rekey 후 (고친 뒤)** | `SERVER-PART-…` | `SERVER-PART-…` | **1개** |

낡은 포트도 정리돼 사라집니다. 실제 경로도 확인했습니다 — `PartNodeApiClient` 가 파트를 서버에 등록한 뒤 부르는 것이 정확히 `ApplyServerNodeId` 입니다.

연결 보류/재전송:

| 항목 | 결과 |
|---|---|
| 미등록 노드로 연결 시도 | 대기 1건 보관 (유실 없음) |
| 노드 등록 후 flush | 대기 0건 (전송) |

**헤드셋 2대 실기 검증은 아직입니다.**